### PR TITLE
Allow multiple variations of `HashMap` and `HashSet`

### DIFF
--- a/bdk_core/Cargo.toml
+++ b/bdk_core/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2021"
 bitcoin = { version = "0.28" }
 miniscript = { git =  "https://github.com/llfourn/rust-miniscript", rev = "2d351c08caca292e8710d74b950bc200f5a539cc" }
 serde_crate = { package = "serde", version = "1", optional = true, features = ["derive"] }
-
+# Use hashbrown as a feature flag to have HashSet and HashMap from it.
+hashbrown = { version = "0.12.1" , optional = true }
 
 [features]
 default = ["std"]

--- a/bdk_core/src/coin_select.rs
+++ b/bdk_core/src/coin_select.rs
@@ -1,6 +1,6 @@
 use bitcoin::{Transaction, TxOut};
 
-use crate::{BTreeSet, Vec};
+use crate::{collections::BTreeSet, Vec};
 
 const TXIN_BASE_WEIGHT: u32 = (32 + 4 + 4 + 1) * 4;
 

--- a/bdk_core/src/descriptor_tracker.rs
+++ b/bdk_core/src/descriptor_tracker.rs
@@ -1,9 +1,5 @@
-use crate::{BlockTime, CheckPoint, HashMap, HashSet, PrevOuts};
-use alloc::{
-    boxed::Box,
-    collections::{BTreeMap, BTreeSet},
-    vec::Vec,
-};
+use crate::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use crate::{BlockTime, Box, CheckPoint, PrevOuts, Vec};
 use bitcoin::{
     psbt::{self, PartiallySignedTransaction as Psbt},
     secp256k1::{Secp256k1, VerifyOnly},


### PR DESCRIPTION
I was trying to tackle the TODO in https://github.com/LLFourn/bdk_core_staging/blob/f6ecd9e2c09f9825792fde4d9967aab71042b93f/bdk_core/src/lib.rs#L48 and ended up changing a bit more than I set to.

I notice the current `--no-default-features` isn't building and the primitive types are getting a bit mixed, because the lib is defined as `no_std` yet have `std` as default. So few primitives that should have linked from `alloc` is being linked from `std` itself.. The problem gets worse when I tried to do feature-gating on `HashMap` and `HashSet` definitions. 

So instead changed the lib feature structure as follow

 - `default` : Always use `core` and `alloc` stuffs.
 - `std` : Only use `std` stuffs where specifically needed, collections and `Box` and other primitives still remains `no-std`.
 - `swisstable`: A special feature that allows Hash collections from hashbrown. If activated with `std` takes precedence over `std::collections::Hash*` stuffs..
 
 After this PR the build instructions looks like this
  - `cargo build` : builds `no-std` with default features (which is empty for now, can have stuffs later)
  - `cargo build --features std` : builds with `std` stuffs on top of `core`.
  - `cargo build --features swisstable` : build `no_std` with `hashbrown`.
  - `cargo build --features=swisstable,std` : build `std` on top of `core` with `hashbrown` for hash collections

Also includes some refactoring of imports.. To me it feels like better to have a single source of definition for primitive types, like BTrees, Vec, Box.. So defined them at `lib.rs` and only included in other module through `use crate::{<include stuffs>}`. This will reduce future confusion of which stuffs are coming from where..

+ One doc nit. 
   