### PR TITLE
add CI linting and codecoverage

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,45 @@
+on: [push, pull_request]
+
+name: continuous_builds
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - nightly 
+        features:
+          - std
+          - hashbrown
+          - serde
+          - std,hasbrown
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Generate cache key
+        run: echo "${{ matrix.rust }} ${{ matrix.features }}" | tee .cache_key
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('.cache_key') }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Set default toolchain
+        run: rustup default ${{ matrix.rust }}
+      - name: Set profile
+        run: rustup set profile minimal
+      - name: Add clippy
+        run: rustup component add clippy
+      - name: Update toolchain
+        run: rustup update
+      - name: Build
+        run: cargo build --package bdk_core --features ${{ matrix.features }} --no-default-features
+      # Uncomment clippy check after failures are removed
+      # - name: Clippy
+      #   run: cargo clippy --all-targets --features ${{ matrix.features }} --no-default-features -- -D warnings

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -1,0 +1,37 @@
+on: [push, pull_request]
+
+name: test_codecov
+
+jobs:
+  test_with_codecov:
+    name: Run tests with coverage reporting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set default toolchain
+        run: rustup default nightly
+      - name: Set profile
+        run: rustup set profile minimal
+
+      # Pin grcov to v0.8.2 because of build failure at 0.8.3
+      - name: Install grcov
+        run: cargo install grcov --force --version 0.8.2
+
+      # Tests are run with code coverage support
+      - name: Run cargo test
+        env:
+          CARGO_INCREMENTAL: '0'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+          RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+        run: cargo test --package bdk_core --features all
+      - id: coverage
+        name: Generate coverage
+        uses: actions-rs/grcov@v0.1.5
+      
+      # Upload coverage report
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ${{ steps.coverage.outputs.report }}
+          directory: ./coverage/reports/

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,22 @@
+on: [push, pull_request]
+
+name: lint
+
+jobs:
+
+  fmt:
+    name: rust fmt
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set default toolchain
+        run: rustup default stable
+      - name: Set profile
+        run: rustup set profile minimal
+      - name: Add rustfmt
+        run: rustup component add rustfmt
+      - name: Update toolchain
+        run: rustup update
+      - name: Check fmt
+        run: cargo fmt --all -- --check


### PR DESCRIPTION
Adding CI testing and code coverage.. 

I couldn't find a good way to check this locally, but I think it should work.. I have put the workflows file in the parent directory and only building and testing bdk_core.. We might need to have another PR open on top of this or merge it in my own branch first to see if github is picking it up properly.. 

To get the coverage reports though we have to add the CodeCov app for the repo.. 

Currently also observing masters is failing due to incompatibility of hashbrown with `DoubleEndedIterator`.. 

```
cargo build --package bdk_core 
   Compiling bdk_core v0.1.0 (/home/raj/github-repo/bdk_core_staging/bdk_core)
error[E0277]: the trait bound `std::collections::hash_set::Iter<'_, bitcoin::Txid>: DoubleEndedIterator` is not satisfied
   --> bdk_core/src/descriptor_tracker.rs:583:37
    |
583 |     pub fn iter_tx_by_age(&self) -> impl DoubleEndedIterator<Item = (Txid, &AugmentedTx)> + '_ {
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `DoubleEndedIterator` is not implemented for `std::collections::hash_set::Iter<'_, bitcoin::Txid>`
    |
    = help: the trait `DoubleEndedIterator` is implemented for `core::iter::Chain<A, B>`
    = note: required because of the requirements on the impl of `DoubleEndedIterator` for `Map<std::collections::hash_set::Iter<'_, bitcoin::Txid>, [closure@bdk_core/src/descriptor_tracker.rs:587:18: 587:61]>`
    = note: 1 redundant requirement hidden
    = note: required because of the requirements on the impl of `DoubleEndedIterator` for `core::iter::Chain<Map<std::collections::hash_set::Iter<'_, bitcoin::Txid>, [closure@bdk_core/src/descriptor_tracker.rs:587:18: 587:61]>, FlatMap<Rev<alloc::collections::btree_map::Iter<'_, u32, _CheckPointData>>, Map<alloc::collections::btree_set::Iter<'_, (u32, bitcoin::Txid)>, [closure@bdk_core/src/descriptor_tracker.rs:591:22: 591:70]>, [closure@bdk_core/src/descriptor_tracker.rs:588:72: 592:10]>>`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `bdk_core` due to previous error
``` 