### PR TITLE
Some basic changes

### DIFF
--- a/bdk_core/src/lib.rs
+++ b/bdk_core/src/lib.rs
@@ -37,15 +37,17 @@ pub struct BlockTime {
     pub time: u64,
 }
 
-/// A reference to a CheckPoint by specific Height and Hash.
+/// A reference to a block in the cannonical chain.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Copy)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
     serde(crate = "serde_crate")
 )]
-pub struct CheckPointRef {
+pub struct BlockId {
+    /// The height the block was confirmed at
     pub height: u32,
+    /// The hash of the block
     pub hash: BlockHash,
 }
 

--- a/bdk_core/src/lib.rs
+++ b/bdk_core/src/lib.rs
@@ -24,7 +24,7 @@ extern crate std;
 extern crate hashbrown;
 
 /// Block height and timestamp of a block
-#[derive(Debug, Clone, PartialEq, Eq, Default, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Copy, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
@@ -37,14 +37,14 @@ pub struct BlockTime {
     pub time: u64,
 }
 
-/// A Blockhash and Blockheight denoting a Checkpoint in the Blockchain.
+/// A reference to a CheckPoint by specific Height and Hash.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Copy)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
     serde(crate = "serde_crate")
 )]
-pub struct CheckPoint {
+pub struct CheckPointRef {
     pub height: u32,
     pub hash: BlockHash,
 }

--- a/bdk_core_example/src/main.rs
+++ b/bdk_core_example/src/main.rs
@@ -378,8 +378,8 @@ pub fn fully_sync_tracker(
 ) -> anyhow::Result<()> {
     let start = std::time::Instant::now();
     eprint!("scanning {} addresses indexes ", name);
-    let update = client
-        .fetch_related_transactions(
+    let checkpoint = client
+        .fetch_new_checkpoint(
             tracker
                 .iter_all_scripts()
                 .enumerate()
@@ -394,6 +394,6 @@ pub fn fully_sync_tracker(
         )
         .context("fetching transactions")?;
     eprintln!("success! ({}ms)", start.elapsed().as_millis());
-    tracker.apply_update(update);
+    tracker.apply_checkpoint(checkpoint);
     Ok(())
 }

--- a/bdk_esplora/src/ureq.rs
+++ b/bdk_esplora/src/ureq.rs
@@ -5,7 +5,7 @@ use bdk_core::{
         hashes::{hex::ToHex, sha256, Hash},
         BlockHash, Script, Transaction, Txid,
     },
-    CheckPointRef, Update,
+    BlockId, CheckpointCandidate,
 };
 pub use ureq;
 use ureq::Agent;
@@ -120,7 +120,7 @@ impl Client {
             .map_err(|_| Error::Deserialization { url })?)
     }
 
-    pub fn tip(&self) -> Result<CheckPointRef, Error> {
+    pub fn tip(&self) -> Result<BlockId, Error> {
         let height = {
             let url = format!("{}/blocks/tip/height", self.base_url);
             let response = self.agent.get(&url).call()?;
@@ -139,10 +139,10 @@ impl Client {
                 .map_err(|_| Error::Deserialization { url })?
         };
 
-        Ok(CheckPointRef { height, hash })
+        Ok(BlockId { height, hash })
     }
 
-    fn is_block_present(&self, block: CheckPointRef) -> Result<bool, ureq::Error> {
+    fn is_block_present(&self, block: BlockId) -> Result<bool, ureq::Error> {
         use core::str::FromStr;
         let url = format!("{}/block-height/{}", self.base_url, block.height);
         let response = self.agent.get(&url).call()?;
@@ -163,13 +163,14 @@ impl Client {
         Ok(())
     }
 
-    /// TODO
-    pub fn fetch_related_transactions(
+    /// Create a new checkpoint with transactions spending from or to the scriptpubkeys in
+    /// `scripts`.
+    pub fn fetch_new_checkpoint(
         &self,
         mut scripts: impl Iterator<Item = (u32, Script)>,
         stop_gap: usize,
-        known_tips: impl Iterator<Item = CheckPointRef>,
-    ) -> Result<Update, UpdateError> {
+        known_tips: impl Iterator<Item = BlockId>,
+    ) -> Result<CheckpointCandidate, UpdateError> {
         let mut empty_scripts = 0;
         let mut transactions = vec![];
         let mut last_active_index = None;
@@ -247,13 +248,12 @@ impl Client {
             return Err(UpdateError::TipChangeDuringUpdate);
         }
 
-        let update = Update {
+        let update = CheckpointCandidate {
             transactions,
             last_active_index,
             base_tip,
             invalidate,
             new_tip,
-            latest_blocktime: None, // TODO: This should be latest blocktime fetched from the client
         };
 
         Ok(update)


### PR DESCRIPTION
@LLFourn  This PR adds the changes as discussed. Made in 2 commits only.. The first one includes all the chunk..

Summary of basic changes:

 - Basic Documentation update. `add_tx`, `remove_tx`, `apply_update` 
 functions have been divided into logical subsections of operations. 
 documenting their action at start of each segment.

 - Previously used `CheckPointTxids` has been replaced with methods on
 top of `CheckPointData` as `get_txids` and `get_accum_digest`.

 - Previously named `CheckPoint` is renamed to `CheckPointRef`, as it
 is by content a "reference" to a CheckPoint, not the CheckPoint itself.

 - Many new TODOs added as per discussion with Lloyd.

 - Add `latest_blocktime` into `Update` structure, as we need some source
 of latest `BlockTime` information.

 - Corresponding changes in tests.