### PR TITLE
Core updates as by product of CBF integration.

### DIFF
--- a/bdk_core/src/sparse_chain.rs
+++ b/bdk_core/src/sparse_chain.rs
@@ -185,12 +185,12 @@ impl SparseChain {
         })
     }
 
-    /// Apply a given block of transactions
+    /// Apply transactions that are all confirmed in a given block
     pub fn apply_block_txs(
         &mut self,
         block_id: BlockId,
-        time: u64,
-        transactions: Vec<Transaction>,
+        block_timestamp: u64,
+        transactions: impl IntoIterator<Item = Transaction>,
     ) -> ApplyResult {
         let mut checkpoint = CheckpointCandidate {
             transactions: transactions
@@ -199,7 +199,7 @@ impl SparseChain {
                     tx,
                     confirmation_time: Some(BlockTime {
                         height: block_id.height,
-                        time,
+                        time: block_timestamp,
                     }),
                 })
                 .collect(),

--- a/bdk_core/src/sparse_chain.rs
+++ b/bdk_core/src/sparse_chain.rs
@@ -185,6 +185,45 @@ impl SparseChain {
         })
     }
 
+    /// Apply a given block of transactions
+    pub fn apply_block_txs(
+        &mut self,
+        block_id: BlockId,
+        time: u64,
+        transactions: Vec<Transaction>,
+    ) -> ApplyResult {
+        let mut checkpoint = CheckpointCandidate {
+            transactions: transactions
+                .into_iter()
+                .map(|tx| TxAtBlock {
+                    tx,
+                    confirmation_time: Some(BlockTime {
+                        height: block_id.height,
+                        time,
+                    }),
+                })
+                .collect(),
+            base_tip: self.latest_checkpoint(),
+            invalidate: None,
+            new_tip: block_id,
+        };
+        if let Some(matching_checkpoint) = self.checkpoint_at(block_id.height) {
+            if matching_checkpoint.hash != block_id.hash {
+                checkpoint.invalidate = Some(matching_checkpoint);
+                checkpoint.base_tip =
+                    self.checkpoints
+                        .range(..block_id.height)
+                        .last()
+                        .map(|(height, data)| BlockId {
+                            height: *height,
+                            hash: data.block_hash,
+                        })
+            }
+        }
+
+        self.apply_checkpoint(checkpoint)
+    }
+
     /// Applies a new candidate checkpoint to the tracker.
     #[must_use]
     pub fn apply_checkpoint(&mut self, mut new_checkpoint: CheckpointCandidate) -> ApplyResult {
@@ -262,6 +301,13 @@ impl SparseChain {
             }
         }
 
+        // If the current tip is empty (i.e. just tracking lastest height) we can just remove it.
+        if let Some(latest_checkpoint) = self.latest_checkpoint() {
+            if self.checkpoint_txids(latest_checkpoint).next().is_none() {
+                self.checkpoints.remove(&latest_checkpoint.height);
+            }
+        }
+
         self.checkpoints
             .entry(new_checkpoint.new_tip.height)
             .or_insert_with(|| CheckpointData {
@@ -275,19 +321,6 @@ impl SparseChain {
                 deepest_change = Some(deepest_change.unwrap_or(u32::MAX).min(change));
             }
         }
-
-        // If no new transactions were added in new_tip, remove it.
-        if self
-            .checkpoints
-            .values()
-            .last()
-            .unwrap()
-            .ordered_txids
-            .is_empty()
-        {
-            self.checkpoints.remove(&new_checkpoint.new_tip.height);
-        }
-
         if let Some(change_depth) = deepest_change {
             self.recompute_txid_digests(change_depth);
         }
@@ -403,15 +436,13 @@ impl SparseChain {
     }
 
     /// Reverse everything of the Block with given hash and height.
-    pub fn disconnect_block(&mut self, block_height: u32, block_hash: BlockHash) {
-        // Can't guarantee that mempool is consistent with chain after we disconnect a block so we
-        // clear it.
-        // TODO: it would be nice if we could only delete those transactions that are
-        // inconsistent by recording the latest block they were included in.
-        self.clear_mempool();
-        if let Some(checkpoint_data) = self.checkpoints.get(&block_height) {
-            if checkpoint_data.block_hash == block_hash {
-                self.invalidate_checkpoint(block_height);
+    pub fn disconnect_block(&mut self, block_id: BlockId) {
+        if let Some(checkpoint_data) = self.checkpoints.get(&block_id.height) {
+            if checkpoint_data.block_hash == block_id.hash {
+                // Can't guarantee that mempool is consistent with chain after we disconnect a block so we
+                // clear it.
+                self.clear_mempool();
+                self.invalidate_checkpoint(block_id.height);
             }
         }
     }
@@ -474,6 +505,9 @@ impl SparseChain {
         }
 
         for input in tx.input.iter() {
+            if input.previous_output.is_null() {
+                continue;
+            }
             let removed = self.spends.insert(input.previous_output, txid);
             debug_assert_eq!(
                 removed, None,

--- a/bdk_core/tests/checkpoint_gen.rs
+++ b/bdk_core/tests/checkpoint_gen.rs
@@ -34,7 +34,7 @@ impl CheckpointGen {
     pub fn new() -> Self {
         Self {
             vout_counter: 0,
-            prev_tip: None,
+            prev_tip: Some(BlockId::default()),
             descriptor: DESCRIPTOR.parse().unwrap(),
         }
     }

--- a/bdk_core/tests/test_keychain_tracker.rs
+++ b/bdk_core/tests/test_keychain_tracker.rs
@@ -22,9 +22,11 @@ fn no_checkpoint_and_then_confirm() {
 
     assert_eq!(chain.apply_checkpoint(checkpoint.clone()), ApplyResult::Ok);
 
+    // TODO: Default SparseChain will create one checkpoint with all 0 values.
+    // Convert the default into genesis block of each network.
     assert_eq!(
         chain.iter_checkpoints(..).count(),
-        0,
+        1,
         "adding tx to mempool doesn't create checkpoint"
     );
     assert_eq!(chain.iter_tx().count(), 1);

--- a/bdk_core/tests/test_keychain_tracker.rs
+++ b/bdk_core/tests/test_keychain_tracker.rs
@@ -4,7 +4,7 @@ use bitcoin::OutPoint;
 use checkpoint_gen::{CheckpointGen, ISpec, OSpec, TxSpec};
 
 #[test]
-fn no_checkpoint_and_then_confirm() {
+fn add_single_unconfirmed_tx_and_then_confirm_it() {
     let mut checkpoint_gen = CheckpointGen::new();
     let mut chain = SparseChain::default();
     let mut tracker = KeychainTracker::default();
@@ -22,13 +22,15 @@ fn no_checkpoint_and_then_confirm() {
 
     assert_eq!(chain.apply_checkpoint(checkpoint.clone()), ApplyResult::Ok);
 
-    // TODO: Default SparseChain will create one checkpoint with all 0 values.
-    // Convert the default into genesis block of each network.
+    assert_eq!(chain.iter_checkpoints(..).count(), 1);
     assert_eq!(
-        chain.iter_checkpoints(..).count(),
-        1,
-        "adding tx to mempool doesn't create checkpoint"
+        chain
+            .checkpoint_txids(chain.latest_checkpoint().unwrap())
+            .count(),
+        0,
+        "the checkpoint should be empty because tx is not confirmed"
     );
+
     assert_eq!(chain.iter_tx().count(), 1);
     tracker.sync(&chain);
 
@@ -47,7 +49,12 @@ fn no_checkpoint_and_then_confirm() {
     checkpoint.new_tip.height += 1;
 
     assert_eq!(chain.apply_checkpoint(checkpoint), ApplyResult::Ok);
+
     {
+        assert_eq!(
+            chain.iter_checkpoints(..).count(), 1,
+            "should only be one since the previous empty one should have been removed in favor of this one");
+        assert_eq!(chain.latest_checkpoint().unwrap().height, 1);
         let txouts = tracker.iter_txout_full(&chain).collect::<Vec<_>>();
         let unspent = tracker.iter_unspent_full(&chain).collect::<Vec<_>>();
         assert_eq!(txouts.len(), 1);

--- a/bdk_core/tests/test_sparse_chain.rs
+++ b/bdk_core/tests/test_sparse_chain.rs
@@ -1,6 +1,6 @@
 use bdk_core::*;
 mod checkpoint_gen;
-use bitcoin::OutPoint;
+use bitcoin::{BlockHash, OutPoint};
 use checkpoint_gen::{CheckpointGen, ISpec, OSpec, TxSpec};
 
 #[test]
@@ -94,7 +94,7 @@ fn invalid_tx_confirmation_time() {
         ApplyResult::Ok
     );
 
-    assert_eq!(chain.iter_checkpoints(..).count(), 0);
+    assert_eq!(chain.iter_checkpoints(..).count(), 1);
     assert_eq!(chain.iter_tx().count(), 0);
 }
 
@@ -185,13 +185,7 @@ fn same_checkpoint_twice_should_be_stale() {
     );
 
     assert_eq!(chain.apply_checkpoint(update.clone()), ApplyResult::Ok);
-    assert_eq!(
-        chain.apply_checkpoint(update),
-        ApplyResult::Stale(StaleReason::BaseTipNotMatching {
-            got: None,
-            expected: chain.latest_checkpoint().unwrap()
-        })
-    );
+    assert_eq!(chain.apply_checkpoint(update), ApplyResult::Ok);
 }
 
 #[test]
@@ -235,7 +229,7 @@ fn adding_checkpoint_which_contains_nothing_new_doesnt_create_new_checkpoint() {
         ..Default::default()
     };
     assert_eq!(chain.apply_checkpoint(update.clone()), ApplyResult::Ok);
-    assert_eq!(chain.iter_checkpoints(..).count(), 1);
+    assert_eq!(chain.iter_checkpoints(..).count(), 2);
 }
 
 #[test]
@@ -454,3 +448,72 @@ fn spent_outpoint_doesnt_exist_but_tx_does() {
 }
 
 // TODO: add test for adding the target
+
+#[test]
+fn empty_checkpoint_doesnt_get_removed() {
+    let mut chain = SparseChain::default();
+    assert_eq!(
+        chain.apply_checkpoint(CheckpointCandidate {
+            transactions: vec![],
+            base_tip: None,
+            invalidate: None,
+            new_tip: BlockId {
+                height: 0,
+                hash: BlockHash::default(),
+            },
+        }),
+        ApplyResult::Ok
+    );
+
+    assert_eq!(
+        chain.latest_checkpoint(),
+        Some(BlockId {
+            height: 0,
+            hash: BlockHash::default()
+        })
+    );
+}
+
+#[test]
+fn two_empty_checkpoints_get_merged() {
+    let mut chain = SparseChain::default();
+    assert_eq!(
+        chain.apply_checkpoint(CheckpointCandidate {
+            transactions: vec![],
+            base_tip: None,
+            invalidate: None,
+            new_tip: BlockId::default(),
+        }),
+        ApplyResult::Ok
+    );
+
+    assert_eq!(
+        chain.latest_checkpoint(),
+        Some(BlockId {
+            height: 0,
+            hash: BlockHash::default()
+        })
+    );
+
+    assert_eq!(
+        chain.apply_checkpoint(CheckpointCandidate {
+            transactions: vec![],
+            base_tip: Some(BlockId::default()),
+            invalidate: None,
+            new_tip: BlockId {
+                height: 1,
+                ..Default::default()
+            },
+        }),
+        ApplyResult::Ok
+    );
+
+    assert_eq!(
+        chain.latest_checkpoint(),
+        Some(BlockId {
+            height: 1,
+            hash: BlockHash::default()
+        })
+    );
+    assert_eq!(chain.iter_checkpoints(..).count(), 1);
+}

--- a/bdk_core/tests/test_sparse_chain.rs
+++ b/bdk_core/tests/test_sparse_chain.rs
@@ -209,7 +209,7 @@ fn adding_checkpoint_where_new_tip_is_base_tip_is_fine() {
 }
 
 #[test]
-fn adding_checkpoint_which_contains_nothing_new_doesnt_create_new_checkpoint() {
+fn adding_checkpoint_which_contains_nothing_new_should_create_single_empty_checkpoint() {
     let mut checkpoint_gen = CheckpointGen::new();
     let mut chain = SparseChain::default();
 
@@ -230,6 +230,16 @@ fn adding_checkpoint_which_contains_nothing_new_doesnt_create_new_checkpoint() {
     };
     assert_eq!(chain.apply_checkpoint(update.clone()), ApplyResult::Ok);
     assert_eq!(chain.iter_checkpoints(..).count(), 2);
+
+    update.base_tip = Some(update.new_tip);
+    update.new_tip = BlockId {
+        height: 2,
+        ..Default::default()
+    };
+    assert_eq!(chain.apply_checkpoint(update.clone()), ApplyResult::Ok);
+    assert_eq!(chain.iter_checkpoints(..).count(), 2);
+    assert_eq!(chain.iter_checkpoints(..).next().unwrap().height, 0);
+    assert_eq!(chain.iter_checkpoints(..).last().unwrap().height, 2);
 }
 
 #[test]


### PR DESCRIPTION
This PR pushes the latest changes applied in the CBF integration to bdk_core. 

Note that by default the SparseChain now creates a zero value genesis checkpoint. For this the existing tests were failing.. Updated the test to cater for the default checkpoint.. But Ideally the default should be the genesis blockhash of each network.

Added a new  `StaleReason::CheckpointAlreadyExists` to handle the test  `same_checkpoint_twice_should_be_stale`.. Though I am not sure if we should stale in this case or just quietly move along.. The previous stale reason wasn't being emitted anymore in this case. With previous logic it was happily applying the the duplicate checkpoint..   