### PR TITLE
Fix calculations for zero feerate

### DIFF
--- a/bdk_core/src/coin_select/coin_selector.rs
+++ b/bdk_core/src/coin_select/coin_selector.rs
@@ -390,7 +390,7 @@ impl<'a> CoinSelector<'a> {
         }
 
         // with drain
-        if fee_with_drain > self.opts.min_absolute_fee
+        if fee_with_drain >= self.opts.min_absolute_fee
             && inputs_minus_outputs >= fee_with_drain + self.opts.min_drain_value
         {
             excess_strategies.insert(


### PR DESCRIPTION
With a feerate of `0sats/wu`, `fee_with_drain` will be `0`. If `min_absolute_fee` is also zero at this stage, we still want to check for the excess strategy  `ToDrain`.