### PR TITLE
Tweaks to `SparseChain`

### DIFF
--- a/bdk_core_example/src/main.rs
+++ b/bdk_core_example/src/main.rs
@@ -9,7 +9,7 @@ use bdk_core::{
     },
     coin_select::{coin_select_bnb, CoinSelector, CoinSelectorOpt, WeightedValue},
     miniscript::{Descriptor, DescriptorPublicKey},
-    ApplyResult, DescriptorExt, KeychainTracker, SparseChain, TxGraph,
+    DescriptorExt, KeychainTracker, SparseChain, TxGraph,
 };
 use bdk_esplora::ureq::{ureq, Client};
 use clap::{Parser, Subcommand};
@@ -446,8 +446,8 @@ pub fn fully_sync(
             .context("fetching transactions")?;
 
         match chain.apply_update(checkpoint) {
-            ApplyResult::Ok => eprintln!("success! ({}ms)", start.elapsed().as_millis()),
-            ApplyResult::Stale(_reason) => {
+            Result::Ok(_) => eprintln!("success! ({}ms)", start.elapsed().as_millis()),
+            Result::Err(_reason) => {
                 unreachable!("we are the only ones accessing the tracker")
             }
         }

--- a/bdk_core_example/src/main.rs
+++ b/bdk_core_example/src/main.rs
@@ -445,7 +445,7 @@ pub fn fully_sync(
             )
             .context("fetching transactions")?;
 
-        match chain.apply_checkpoint(checkpoint) {
+        match chain.apply_update(checkpoint) {
             ApplyResult::Ok => eprintln!("success! ({}ms)", start.elapsed().as_millis()),
             ApplyResult::Stale(_reason) => {
                 unreachable!("we are the only ones accessing the tracker")

--- a/bdk_esplora/src/ureq.rs
+++ b/bdk_esplora/src/ureq.rs
@@ -247,7 +247,7 @@ impl Client {
         let update = Update {
             txids: transactions
                 .iter()
-                .map(|(tx, conf)| (tx.txid(), conf.map(|b| b.height)))
+                .map(|(tx, conf)| (tx.txid(), conf.map(|b| b.height).into()))
                 .collect(),
             last_valid,
             invalidate,

--- a/bdk_esplora/src/ureq.rs
+++ b/bdk_esplora/src/ureq.rs
@@ -5,7 +5,7 @@ use bdk_core::{
         hashes::{hex::ToHex, sha256, Hash},
         BlockHash, Script, Transaction, Txid,
     },
-    BlockId, CheckpointCandidate,
+    BlockId, Update,
 };
 pub use ureq;
 use ureq::Agent;
@@ -170,7 +170,7 @@ impl Client {
         mut scripts: impl Iterator<Item = (u32, Script)>,
         stop_gap: usize,
         known_tips: impl Iterator<Item = BlockId>,
-    ) -> Result<(Option<u32>, CheckpointCandidate), UpdateError> {
+    ) -> Result<(Option<u32>, Update), UpdateError> {
         let mut empty_scripts = 0;
         let mut transactions = vec![];
         let mut last_active_index = None;
@@ -244,7 +244,7 @@ impl Client {
             return Err(UpdateError::TipChangeDuringUpdate);
         }
 
-        let update = CheckpointCandidate {
+        let update = Update {
             txids: transactions
                 .iter()
                 .map(|(tx, conf)| (tx.txid(), conf.map(|b| b.height)))


### PR DESCRIPTION
Various tweaks to `SparseChain` before we move on with #32 
* Rename `CheckpointCandidate` to `Update` and updated documentation.
* Implement `Error` and `Display` for `StaleReason` and remove `ApplyResult` (which we replace with `Result` to be more idiomatic).
* Change `Update::txids` to use `HashMap`, therefore implicitly enforcing non-duplicate txids.