### PR TITLE
Introduce `SparseChain` index extension

### DIFF
--- a/bdk_core/src/chain_graph.rs
+++ b/bdk_core/src/chain_graph.rs
@@ -55,7 +55,7 @@ impl<E: ChainIndexExtension> ChainGraph<E> {
         &self.graph
     }
 
-    pub fn apply_update(&mut self, update: &Self) -> Result<ChangeSet<E>, UpdateFailure> {
+    pub fn apply_update(&mut self, update: &Self) -> Result<ChangeSet<E>, UpdateFailure<E>> {
         let changeset = self.chain.determine_changeset(update.chain())?;
         changeset
             .tx_additions()

--- a/bdk_core/src/chain_graph.rs
+++ b/bdk_core/src/chain_graph.rs
@@ -1,5 +1,3 @@
-use core::borrow::Borrow;
-
 use bitcoin::{OutPoint, Transaction, TxOut, Txid};
 
 use crate::{
@@ -48,7 +46,7 @@ impl<D: Clone + core::fmt::Debug + Default + Ord> ChainGraph<D> {
     }
 
     pub fn apply_update(&mut self, update: &Self) -> Result<ChangeSet<D>, UpdateFailure> {
-        let changeset = self.chain.determine_changeset(update)?;
+        let changeset = self.chain.determine_changeset(update.chain())?;
         changeset
             .tx_additions()
             .map(|new_txid| update.graph.tx(new_txid).expect("tx should exist"))
@@ -57,17 +55,5 @@ impl<D: Clone + core::fmt::Debug + Default + Ord> ChainGraph<D> {
             });
         self.chain.apply_changeset(&changeset);
         Ok(changeset)
-    }
-}
-
-impl<D> Borrow<SparseChain<D>> for ChainGraph<D> {
-    fn borrow(&self) -> &SparseChain<D> {
-        &self.chain
-    }
-}
-
-impl<D> Borrow<TxGraph> for ChainGraph<D> {
-    fn borrow(&self) -> &TxGraph {
-        &self.graph
     }
 }

--- a/bdk_core/src/lib.rs
+++ b/bdk_core/src/lib.rs
@@ -116,6 +116,7 @@ pub mod collections {
     pub type HashSet<K> = hashbrown::HashSet<K>;
     pub type HashMap<K, V> = hashbrown::HashMap<K, V>;
     pub use alloc::collections::*;
+    pub use core::ops::Bound;
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/bdk_core/src/lib.rs
+++ b/bdk_core/src/lib.rs
@@ -50,6 +50,12 @@ pub struct BlockTime {
     pub time: u64,
 }
 
+impl From<(u32, u64)> for BlockTime {
+    fn from((height, time): (u32, u64)) -> Self {
+        Self { height, time }
+    }
+}
+
 /// A reference to a block in the cannonical chain.
 #[derive(Debug, Clone, PartialEq, Eq, Copy, PartialOrd, Ord)]
 #[cfg_attr(

--- a/bdk_core/src/sparse_chain.rs
+++ b/bdk_core/src/sparse_chain.rs
@@ -1,5 +1,4 @@
 use core::{
-    borrow::Borrow,
     fmt::Display,
     ops::{Bound, RangeBounds},
 };
@@ -142,12 +141,7 @@ impl<D: Clone + core::fmt::Debug + Default + Ord> SparseChain<D> {
         }
     }
 
-    pub fn determine_changeset<U>(&self, update: &U) -> Result<ChangeSet<D>, UpdateFailure>
-    where
-        U: Borrow<Self>,
-    {
-        let update: &Self = update.borrow();
-
+    pub fn determine_changeset(&self, update: &Self) -> Result<ChangeSet<D>, UpdateFailure> {
         let agreement_point = update
             .checkpoints
             .iter()
@@ -249,10 +243,7 @@ impl<D: Clone + core::fmt::Debug + Default + Ord> SparseChain<D> {
 
     /// Applies a new [`Update`] to the tracker.
     #[must_use]
-    pub fn apply_update<U>(&mut self, update: &U) -> Result<ChangeSet<D>, UpdateFailure>
-    where
-        U: Borrow<Self>,
-    {
+    pub fn apply_update(&mut self, update: &Self) -> Result<ChangeSet<D>, UpdateFailure> {
         let changeset = self.determine_changeset(update)?;
         self.apply_changeset(&changeset);
         Ok(changeset)

--- a/bdk_core/src/sparse_chain.rs
+++ b/bdk_core/src/sparse_chain.rs
@@ -636,6 +636,11 @@ pub trait ChainIndexExtension:
     const MAX: Self;
 }
 
+impl<E: ChainIndexExtension> ChainIndexExtension for Option<E> {
+    const MIN: Self = None;
+    const MAX: Self = Some(E::MAX);
+}
+
 impl ChainIndexExtension for () {
     const MIN: Self = ();
     const MAX: Self = ();
@@ -644,6 +649,11 @@ impl ChainIndexExtension for () {
 impl ChainIndexExtension for u32 {
     const MIN: Self = u32::MIN;
     const MAX: Self = u32::MAX;
+}
+
+impl ChainIndexExtension for u64 {
+    const MIN: Self = u64::MIN;
+    const MAX: Self = u64::MAX;
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/bdk_core/src/spk_tracker.rs
+++ b/bdk_core/src/spk_tracker.rs
@@ -87,7 +87,7 @@ impl<I: Clone + Ord> SpkTracker<I> {
                     txout: txout.clone(),
                     height: data.height,
                     spent_by: Default::default(),
-                    data: data.data,
+                    additional_data: data.additional,
                 },
             ))
         })

--- a/bdk_core/tests/test_sparse_chain.rs
+++ b/bdk_core/tests/test_sparse_chain.rs
@@ -165,8 +165,8 @@ fn invalidate_a_checkpoint_and_try_and_move_tx_when_it_wasnt_within_invalidation
         chain1.determine_changeset(&chain2),
         Err(UpdateFailure::InconsistentTx {
             inconsistent_txid: h!("tx0"),
-            original_height: TxHeight::Confirmed(0),
-            update_height: TxHeight::Confirmed(1)
+            original_index: TxHeight::Confirmed(0).into(),
+            update_index: TxHeight::Confirmed(1).into(),
         })
     );
 }

--- a/bdk_core/tests/test_sparse_chain.rs
+++ b/bdk_core/tests/test_sparse_chain.rs
@@ -7,7 +7,7 @@ macro_rules! chain {
 
         $(
             $(
-                chain.insert_tx_with_additional_data($txid, $tx_height.into()).unwrap();
+                chain.insert_tx($txid, $tx_height).unwrap();
             )*
         )?
 
@@ -258,7 +258,7 @@ fn merging_mempool_of_empty_chains_doesnt_fail() {
 fn cannot_insert_confirmed_tx_without_checkpoints() {
     let mut chain = SparseChain::<()>::default();
     assert_eq!(
-        chain.insert_tx_with_additional_data(h!("A"), TxHeight::Confirmed(0).into()),
+        chain.insert_tx(h!("A"), TxHeight::Confirmed(0)),
         Err(InsertTxErr::TxTooHigh)
     );
 }

--- a/bdk_core/tests/test_sparse_chain.rs
+++ b/bdk_core/tests/test_sparse_chain.rs
@@ -7,7 +7,7 @@ macro_rules! chain {
 
         $(
             $(
-                chain.insert_tx($txid, $tx_height.into()).unwrap();
+                chain.insert_tx_with_additional_data($txid, $tx_height.into()).unwrap();
             )*
         )?
 
@@ -258,7 +258,7 @@ fn merging_mempool_of_empty_chains_doesnt_fail() {
 fn cannot_insert_confirmed_tx_without_checkpoints() {
     let mut chain = SparseChain::<()>::default();
     assert_eq!(
-        chain.insert_tx(h!("A"), TxHeight::Confirmed(0).into()),
+        chain.insert_tx_with_additional_data(h!("A"), TxHeight::Confirmed(0).into()),
         Err(InsertTxErr::TxTooHigh)
     );
 }

--- a/bdk_core/tests/test_sparse_chain.rs
+++ b/bdk_core/tests/test_sparse_chain.rs
@@ -1,5 +1,8 @@
-use bdk_core::{collections::Bound, *};
-use bitcoin::Txid;
+use bdk_core::{
+    collections::{BTreeSet, Bound},
+    *,
+};
+use bitcoin::{hashes::Hash, Txid};
 
 macro_rules! chain {
     ($([$($tt:tt)*]),*) => { chain!( checkpoints: [$([$($tt)*]),*] ) };
@@ -483,7 +486,7 @@ fn checkpoint_limit_is_respected() {
 }
 
 #[test]
-fn range_txids() {
+fn range_txids_by_index() {
     let mut chain = SparseChain::<u32>::from_checkpoints([
         (1, h!("block 1")).into(),
         (2, h!("block 2")).into(),
@@ -504,13 +507,13 @@ fn range_txids() {
     // inclusive start
     assert_eq!(
         chain
-            .range_txids((TxHeight::Confirmed(1), u32::MIN)..)
+            .range_txids_by_index((TxHeight::Confirmed(1), u32::MIN)..)
             .collect::<Vec<_>>(),
         txids.iter().collect::<Vec<_>>(),
     );
     assert_eq!(
         chain
-            .range_txids((TxHeight::Confirmed(1), u32::MAX)..)
+            .range_txids_by_index((TxHeight::Confirmed(1), u32::MAX)..)
             .collect::<Vec<_>>(),
         txids[1..].iter().collect::<Vec<_>>(),
     );
@@ -518,7 +521,7 @@ fn range_txids() {
     // exclusive start
     assert_eq!(
         chain
-            .range_txids((
+            .range_txids_by_index((
                 Bound::Excluded((TxHeight::Confirmed(1), u32::MIN)),
                 Bound::Unbounded
             ))
@@ -527,7 +530,7 @@ fn range_txids() {
     );
     assert_eq!(
         chain
-            .range_txids((
+            .range_txids_by_index((
                 Bound::Excluded((TxHeight::Confirmed(1), u32::MAX)),
                 Bound::Unbounded
             ))
@@ -538,7 +541,7 @@ fn range_txids() {
     // inclusive end
     assert_eq!(
         chain
-            .range_txids((
+            .range_txids_by_index((
                 Bound::Unbounded,
                 Bound::Included((TxHeight::Confirmed(2), u32::MIN))
             ))
@@ -547,7 +550,7 @@ fn range_txids() {
     );
     assert_eq!(
         chain
-            .range_txids((
+            .range_txids_by_index((
                 Bound::Unbounded,
                 Bound::Included((TxHeight::Confirmed(2), u32::MAX))
             ))
@@ -558,14 +561,78 @@ fn range_txids() {
     // exclusive end
     assert_eq!(
         chain
-            .range_txids(..(TxHeight::Confirmed(2), u32::MIN))
+            .range_txids_by_index(..(TxHeight::Confirmed(2), u32::MIN))
             .collect::<Vec<_>>(),
         txids[..2].iter().collect::<Vec<_>>(),
     );
     assert_eq!(
         chain
-            .range_txids(..(TxHeight::Confirmed(2), u32::MAX))
+            .range_txids_by_index(..(TxHeight::Confirmed(2), u32::MAX))
             .collect::<Vec<_>>(),
         txids[..3].iter().collect::<Vec<_>>(),
     );
+}
+
+#[test]
+fn range_txids() {
+    let mut chain = SparseChain::default();
+
+    let txids = (0..100)
+        .map(|v| Txid::hash(v.to_string().as_bytes()))
+        .collect::<BTreeSet<Txid>>();
+
+    // populate chain
+    for txid in &txids {
+        chain
+            .insert_tx(*txid, TxHeight::Unconfirmed)
+            .expect("should succeed");
+    }
+
+    for txid in &txids {
+        assert_eq!(
+            chain
+                .range_txids((TxHeight::Unconfirmed, *txid)..)
+                .map(|(_, txid)| txid)
+                .collect::<Vec<_>>(),
+            txids.range(*txid..).collect::<Vec<_>>(),
+            "range with inclusive start should succeed"
+        );
+
+        assert_eq!(
+            chain
+                .range_txids((
+                    Bound::Excluded((TxHeight::Unconfirmed, *txid)),
+                    Bound::Unbounded,
+                ))
+                .map(|(_, txid)| txid)
+                .collect::<Vec<_>>(),
+            txids
+                .range((Bound::Excluded(*txid), Bound::Unbounded,))
+                .collect::<Vec<_>>(),
+            "range with exclusive start should succeed"
+        );
+
+        assert_eq!(
+            chain
+                .range_txids(..(TxHeight::Unconfirmed, *txid))
+                .map(|(_, txid)| txid)
+                .collect::<Vec<_>>(),
+            txids.range(..*txid).collect::<Vec<_>>(),
+            "range with exclusive end should succeed"
+        );
+
+        assert_eq!(
+            chain
+                .range_txids((
+                    Bound::Included((TxHeight::Unconfirmed, *txid)),
+                    Bound::Unbounded,
+                ))
+                .map(|(_, txid)| txid)
+                .collect::<Vec<_>>(),
+            txids
+                .range((Bound::Included(*txid), Bound::Unbounded,))
+                .collect::<Vec<_>>(),
+            "range with inclusive end should succeed"
+        );
+    }
 }

--- a/bdk_core_example/src/main.rs
+++ b/bdk_core_example/src/main.rs
@@ -14,7 +14,7 @@ use bdk_core::{
 };
 use bdk_esplora::ureq::{ureq, Client};
 use clap::{Parser, Subcommand};
-use std::{borrow::Borrow, cmp::Reverse, time::Duration};
+use std::{cmp::Reverse, time::Duration};
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -190,15 +190,16 @@ fn main() -> anyhow::Result<()> {
             }
         }
         Commands::Balance => {
-            let (confirmed, unconfirmed) = tracker
-                .iter_unspent(chain.borrow(), chain.borrow())
-                .fold((0, 0), |(confirmed, unconfirmed), ((keychain, _), utxo)| {
+            let (confirmed, unconfirmed) = tracker.iter_unspent(chain.chain(), chain.graph()).fold(
+                (0, 0),
+                |(confirmed, unconfirmed), ((keychain, _), utxo)| {
                     if utxo.height.is_confirmed() || keychain == Keychain::Internal {
                         (confirmed + utxo.txout.value, unconfirmed)
                     } else {
                         (confirmed, unconfirmed + utxo.txout.value)
                     }
-                });
+                },
+            );
 
             println!("confirmed: {}", confirmed);
             println!("unconfirmed: {}", unconfirmed);

--- a/bdk_core_example/src/main.rs
+++ b/bdk_core_example/src/main.rs
@@ -193,7 +193,7 @@ fn main() -> anyhow::Result<()> {
             let (confirmed, unconfirmed) = tracker.iter_unspent(chain.chain(), chain.graph()).fold(
                 (0, 0),
                 |(confirmed, unconfirmed), ((keychain, _), utxo)| {
-                    if utxo.height.is_confirmed() || keychain == Keychain::Internal {
+                    if utxo.chain_index.height.is_confirmed() || keychain == Keychain::Internal {
                         (confirmed + utxo.txout.value, unconfirmed)
                     } else {
                         (confirmed, unconfirmed + utxo.txout.value)
@@ -257,9 +257,11 @@ fn main() -> anyhow::Result<()> {
                 CoinSelectionAlgo::SmallestFirst => {
                     candidates.sort_by_key(|(_, utxo)| utxo.txout.value)
                 }
-                CoinSelectionAlgo::OldestFirst => candidates.sort_by_key(|(_, utxo)| utxo.height),
+                CoinSelectionAlgo::OldestFirst => {
+                    candidates.sort_by_key(|(_, utxo)| utxo.chain_index.height)
+                }
                 CoinSelectionAlgo::NewestFirst => {
-                    candidates.sort_by_key(|(_, utxo)| Reverse(utxo.height))
+                    candidates.sort_by_key(|(_, utxo)| Reverse(utxo.chain_index.height))
                 }
                 CoinSelectionAlgo::BranchAndBound => {}
             }

--- a/bdk_core_example/src/main.rs
+++ b/bdk_core_example/src/main.rs
@@ -427,7 +427,7 @@ fn main() -> anyhow::Result<()> {
 pub fn fully_sync(
     client: &Client,
     tracker: &mut KeychainTracker<Keychain>,
-    chain: &mut ChainGraph,
+    chain: &mut ChainGraph<()>,
 ) -> anyhow::Result<()> {
     let start = std::time::Instant::now();
     let mut active_indexes = vec![];

--- a/bdk_esplora/src/ureq.rs
+++ b/bdk_esplora/src/ureq.rs
@@ -182,7 +182,7 @@ impl Client {
         mut scripts: impl Iterator<Item = (u32, Script)> + Clone,
         stop_gap: usize,
         existing_chain: &BTreeMap<u32, BlockHash>,
-    ) -> Result<(Option<u32>, ChainGraph<()>), UpdateError> {
+    ) -> Result<(Option<u32>, ChainGraph), UpdateError> {
         let mut empty_scripts = 0;
         let mut update = ChainGraph::default();
         let mut last_active_index = None;

--- a/bdk_esplora/src/ureq.rs
+++ b/bdk_esplora/src/ureq.rs
@@ -5,7 +5,7 @@ use bdk_core::{
         hashes::{hex::ToHex, sha256, Hash},
         BlockHash, Script, Transaction, Txid,
     },
-    BlockId, ChainGraph, InsertCheckpointErr, InsertTxErr,
+    BlockId, ChainGraph, InsertCheckpointErr, InsertTxErr, TxHeight,
 };
 use std::collections::{BTreeMap, BTreeSet};
 pub use ureq;
@@ -256,9 +256,8 @@ impl Client {
                     empty_scripts = 0;
                 }
                 for tx in related_txs {
-                    if let Err(err) = update
-                        .insert_tx_with_additional_data(tx.to_tx(), tx.status.block_height.into())
-                    {
+                    let tx_conf: TxHeight = tx.status.block_height.into();
+                    if let Err(err) = update.insert_tx(tx.to_tx(), tx_conf) {
                         match err {
                             InsertTxErr::TxTooHigh => {
                                 /* Don't care about new transactions confirmed while syncing */

--- a/bdk_esplora/src/ureq.rs
+++ b/bdk_esplora/src/ureq.rs
@@ -182,7 +182,7 @@ impl Client {
         mut scripts: impl Iterator<Item = (u32, Script)> + Clone,
         stop_gap: usize,
         existing_chain: &BTreeMap<u32, BlockHash>,
-    ) -> Result<(Option<u32>, ChainGraph), UpdateError> {
+    ) -> Result<(Option<u32>, ChainGraph<()>), UpdateError> {
         let mut empty_scripts = 0;
         let mut update = ChainGraph::default();
         let mut last_active_index = None;

--- a/bdk_esplora/src/ureq.rs
+++ b/bdk_esplora/src/ureq.rs
@@ -256,7 +256,9 @@ impl Client {
                     empty_scripts = 0;
                 }
                 for tx in related_txs {
-                    if let Err(err) = update.insert_tx(tx.to_tx(), tx.status.block_height.into()) {
+                    if let Err(err) = update
+                        .insert_tx_with_additional_data(tx.to_tx(), tx.status.block_height.into())
+                    {
                         match err {
                             InsertTxErr::TxTooHigh => {
                                 /* Don't care about new transactions confirmed while syncing */


### PR DESCRIPTION
> This description is mostly copied from #61

Usually transactions are indexed by their height. But you might want to extend this (e.g. include block position) or some other metadata.

I've made the index quite restrictive (e.g. requires Copy) since we'll need to persist the data and for our simple file based persistence we'll need it to be fixed size for now.

This fixes a bug where an inclusive txid range search would not find the txids because we set the range to `Txid::all_zeros` (unless the txid was all zeroes). 

I also added an API to search via the index itself. Handy if you want to do pagination of  transactions by your own index (a good one would be block position) as mentioned in https://github.com/bitcoindevkit/bdk/issues/794

### To Do
- [x] Add test for *"This fixes a bug where an inclusive txid range search would not find the txids because we set the range to `Txid::all_zeros` (unless the txid was all zeroes)"*.