### PR TITLE
Allow custom chain index parameter

### DIFF
--- a/bdk_core/src/chain_graph.rs
+++ b/bdk_core/src/chain_graph.rs
@@ -2,13 +2,22 @@ use bitcoin::{OutPoint, Transaction, TxOut, Txid};
 
 use crate::{
     BlockId, ChainIndex, ChangeSet, InsertCheckpointErr, InsertTxErr, SparseChain, TxGraph,
-    UpdateFailure,
+    TxHeight, UpdateFailure,
 };
 
-#[derive(Clone, Debug, Default)]
-pub struct ChainGraph<I> {
+#[derive(Clone, Debug)]
+pub struct ChainGraph<I = TxHeight> {
     chain: SparseChain<I>,
     graph: TxGraph,
+}
+
+impl<I> Default for ChainGraph<I> {
+    fn default() -> Self {
+        Self {
+            chain: Default::default(),
+            graph: Default::default(),
+        }
+    }
 }
 
 impl<I> ChainGraph<I>

--- a/bdk_core/src/sparse_chain.rs
+++ b/bdk_core/src/sparse_chain.rs
@@ -4,7 +4,7 @@ use core::{
 };
 
 use crate::{collections::*, BlockId, TxGraph, Vec};
-use bitcoin::{hashes::Hash, BlockHash, OutPoint, Transaction, TxOut, Txid};
+use bitcoin::{hashes::Hash, BlockHash, OutPoint, TxOut, Txid};
 
 #[derive(Clone, Debug)]
 pub struct SparseChain<I = TxHeight> {
@@ -487,59 +487,6 @@ where
     pub fn is_unspent(&self, graph: &TxGraph, outpoint: OutPoint) -> Option<bool> {
         let txids = graph.outspend(outpoint)?;
         Some(txids.iter().all(|&txid| self.chain_index(txid).is_none()))
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum TxKey {
-    Txid(Txid),
-    Tx(Transaction),
-}
-
-impl TxKey {
-    pub fn txid(&self) -> Txid {
-        match self {
-            TxKey::Txid(txid) => *txid,
-            TxKey::Tx(tx) => tx.txid(),
-        }
-    }
-}
-
-impl From<Txid> for TxKey {
-    fn from(txid: Txid) -> Self {
-        Self::Txid(txid)
-    }
-}
-
-impl From<Transaction> for TxKey {
-    fn from(tx: Transaction) -> Self {
-        Self::Tx(tx)
-    }
-}
-
-impl PartialEq for TxKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.txid() == other.txid()
-    }
-}
-
-impl Eq for TxKey {}
-
-impl PartialOrd for TxKey {
-    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for TxKey {
-    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        self.txid().cmp(&other.txid())
-    }
-}
-
-impl core::hash::Hash for TxKey {
-    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.txid().hash(state)
     }
 }
 

--- a/bdk_core/src/spk_tracker.rs
+++ b/bdk_core/src/spk_tracker.rs
@@ -2,7 +2,7 @@ use core::ops::RangeBounds;
 
 use crate::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    FullTxOut, SparseChain, TxGraph,
+    ChainIndex, FullTxOut, SparseChain, TxGraph,
 };
 use bitcoin::{self, OutPoint, Script, Transaction, TxOut, Txid};
 
@@ -70,21 +70,22 @@ impl<I: Clone + Ord> SpkTracker<I> {
             .map(|(op, (index, txout))| (index.clone(), *op, txout))
     }
 
-    pub fn iter_unspent<'a>(
+    pub fn iter_unspent<'a, CI: ChainIndex>(
         &'a self,
-        chain: &'a SparseChain,
+        chain: &'a SparseChain<CI>,
         graph: &'a TxGraph,
-    ) -> impl DoubleEndedIterator<Item = (I, FullTxOut)> + '_ {
+    ) -> impl DoubleEndedIterator<Item = (I, FullTxOut<CI>)> + '_ {
         self.iter_txout().filter_map(|(index, outpoint, txout)| {
             if !chain.is_unspent(graph, outpoint)? {
                 return None;
             }
+            let chain_index = chain.chain_index(outpoint.txid)?.clone();
             Some((
                 index,
                 FullTxOut {
                     outpoint,
                     txout: txout.clone(),
-                    height: chain.transaction_height(outpoint.txid)?,
+                    chain_index,
                     spent_by: Default::default(),
                 },
             ))

--- a/bdk_core/tests/test_sparse_chain.rs
+++ b/bdk_core/tests/test_sparse_chain.rs
@@ -3,7 +3,7 @@ macro_rules! chain {
     ($([$($tt:tt)*]),*) => { chain!( checkpoints: [$([$($tt)*]),*] ) };
     (checkpoints: [ $([$height:expr, $block_hash:expr]),* ] $(,txids: [$(($txid:expr, $tx_height:expr)),*])?) => {{
         #[allow(unused_mut)]
-        let mut chain = SparseChain::from_checkpoints(vec![$(($height, $block_hash).into()),*]);
+        let mut chain = SparseChain::<TxHeight>::from_checkpoints(vec![$(($height, $block_hash).into()),*]);
 
         $(
             $(
@@ -47,7 +47,7 @@ macro_rules! changeset {
 
 #[test]
 fn add_first_checkpoint() {
-    let chain = SparseChain::default();
+    let chain: SparseChain = Default::default();
     assert_eq!(
         chain.determine_changeset(&chain!([0, h!("A")])),
         Ok(changeset! {
@@ -161,8 +161,8 @@ fn invalidate_a_checkpoint_and_try_and_move_tx_when_it_wasnt_within_invalidation
         chain1.determine_changeset(&chain2),
         Err(UpdateFailure::InconsistentTx {
             inconsistent_txid: h!("tx0"),
-            original_height: TxHeight::Confirmed(0),
-            update_height: TxHeight::Confirmed(1)
+            original_index: TxHeight::Confirmed(0),
+            update_index: TxHeight::Confirmed(1)
         })
     );
 }

--- a/bdk_core_example/src/main.rs
+++ b/bdk_core_example/src/main.rs
@@ -14,7 +14,7 @@ use bdk_core::{
 };
 use bdk_esplora::ureq::{ureq, Client};
 use clap::{Parser, Subcommand};
-use std::{borrow::Borrow, cmp::Reverse, time::Duration};
+use std::{cmp::Reverse, time::Duration};
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -190,15 +190,16 @@ fn main() -> anyhow::Result<()> {
             }
         }
         Commands::Balance => {
-            let (confirmed, unconfirmed) = tracker
-                .iter_unspent(chain.borrow(), chain.borrow())
-                .fold((0, 0), |(confirmed, unconfirmed), ((keychain, _), utxo)| {
-                    if utxo.height.is_confirmed() || keychain == Keychain::Internal {
+            let (confirmed, unconfirmed) = tracker.iter_unspent(chain.chain(), chain.graph()).fold(
+                (0, 0),
+                |(confirmed, unconfirmed), ((keychain, _), utxo)| {
+                    if utxo.chain_index.is_confirmed() || keychain == Keychain::Internal {
                         (confirmed + utxo.txout.value, unconfirmed)
                     } else {
                         (confirmed, unconfirmed + utxo.txout.value)
                     }
-                });
+                },
+            );
 
             println!("confirmed: {}", confirmed);
             println!("unconfirmed: {}", unconfirmed);
@@ -256,9 +257,11 @@ fn main() -> anyhow::Result<()> {
                 CoinSelectionAlgo::SmallestFirst => {
                     candidates.sort_by_key(|(_, utxo)| utxo.txout.value)
                 }
-                CoinSelectionAlgo::OldestFirst => candidates.sort_by_key(|(_, utxo)| utxo.height),
+                CoinSelectionAlgo::OldestFirst => {
+                    candidates.sort_by_key(|(_, utxo)| utxo.chain_index)
+                }
                 CoinSelectionAlgo::NewestFirst => {
-                    candidates.sort_by_key(|(_, utxo)| Reverse(utxo.height))
+                    candidates.sort_by_key(|(_, utxo)| Reverse(utxo.chain_index))
                 }
                 CoinSelectionAlgo::BranchAndBound => {}
             }


### PR DESCRIPTION
Usually transactions are indexed by their height. But you might want to extend this (e.g. include block position) or some other metadata.

I've made the index quite restrictive (e.g. requires Copy) since we'll need to persist the data and for our simple file based persistence we'll need it to be fixed size for now.

This supersedes #60.

TODO: This fixes a bug where an inclusive txid range search would not find the txids because we set the range to `Txid::all_zeros` (unless the txid was all zeroes). We need a test for that. I also added an API to search via the index itself. Handy if you want to do pagination of  transactions by your own index (a good one would be block position) as mentioned in https://github.com/bitcoindevkit/bdk/issues/794