### PR TITLE
Introduce `range_txids_by_height` and introduce timestamps to esplora example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target
 Cargo.lock
+
+out.perf-folded
+perf.data
+rust-perf.svg

--- a/bdk_core/src/chain_data.rs
+++ b/bdk_core/src/chain_data.rs
@@ -48,24 +48,16 @@ impl From<TxHeight> for Option<u32> {
 }
 
 impl sparse_chain::ChainIndex for TxHeight {
-    type Extension = ();
-    const EXTENSION_MIN: Self::Extension = ();
-    const EXTENSION_MAX: Self::Extension = ();
-
     fn height(&self) -> TxHeight {
         *self
     }
 
-    fn extension(&self) -> Self::Extension {
-        ()
+    fn max_ord_of_height(height: TxHeight) -> Self {
+        height
     }
 
-    fn into_ordered_key(self) -> (TxHeight, Self::Extension) {
-        (self, ())
-    }
-
-    fn from_ordered_key(key: (TxHeight, Self::Extension)) -> Self {
-        key.0
+    fn min_ord_of_height(height: TxHeight) -> Self {
+        height
     }
 }
 
@@ -76,7 +68,7 @@ impl TxHeight {
 }
 
 /// Block height and timestamp in which a transaction is confirmed in.
-#[derive(Debug, Clone, PartialEq, Eq, Copy, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, PartialOrd, Ord, core::hash::Hash)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
@@ -88,27 +80,19 @@ pub struct ConfirmationTime {
 }
 
 impl sparse_chain::ChainIndex for ConfirmationTime {
-    type Extension = Option<u64>;
-    const EXTENSION_MIN: Self::Extension = None;
-    const EXTENSION_MAX: Self::Extension = Some(u64::MAX);
-
     fn height(&self) -> TxHeight {
         self.height
     }
 
-    fn extension(&self) -> Self::Extension {
-        self.time
-    }
-
-    fn into_ordered_key(self) -> (TxHeight, Self::Extension) {
-        (self.height, self.time)
-    }
-
-    fn from_ordered_key(key: (TxHeight, Self::Extension)) -> Self {
+    fn max_ord_of_height(height: TxHeight) -> Self {
         Self {
-            height: key.0,
-            time: key.1,
+            height,
+            time: Some(u64::MAX),
         }
+    }
+
+    fn min_ord_of_height(height: TxHeight) -> Self {
+        Self { height, time: None }
     }
 }
 

--- a/bdk_core/src/chain_data.rs
+++ b/bdk_core/src/chain_data.rs
@@ -1,4 +1,4 @@
-use crate::sparse_chain::{self, ChainIndex, ChainIndexExtension};
+use crate::sparse_chain::{self, ChainIndex, ChainIndexExtension, TimestampedChainIndex};
 use bitcoin::{hashes::Hash, BlockHash, OutPoint, TxOut, Txid};
 
 /// Represents the height in which a transaction is confirmed at.
@@ -53,7 +53,7 @@ impl TxHeight {
 }
 
 /// Block height and timestamp in which a transaction is confirmed in.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Copy, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
@@ -61,7 +61,7 @@ impl TxHeight {
 )]
 pub struct ConfirmationTime {
     pub height: TxHeight,
-    pub time: Option<u64>,
+    pub time: Timestamp,
 }
 
 impl ConfirmationTime {
@@ -125,6 +125,11 @@ pub struct FullTxOut<E> {
 
 /// A wrapped `u64` for use as a [`ChainIndexExtension`](crate::sparse_chain::ChainIndexExtension)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(crate = "serde_crate")
+)]
 pub struct Timestamp(pub u64);
 
 impl ChainIndexExtension for Timestamp {
@@ -132,11 +137,11 @@ impl ChainIndexExtension for Timestamp {
     const MAX: Self = Timestamp(u64::MAX);
 }
 
-impl From<ConfirmationTime> for ChainIndex<Option<Timestamp>> {
+impl From<ConfirmationTime> for TimestampedChainIndex {
     fn from(ct: ConfirmationTime) -> Self {
         ChainIndex {
             height: ct.height,
-            extension: ct.time.map(Timestamp),
+            extension: ct.time,
         }
     }
 }

--- a/bdk_core/src/chain_data.rs
+++ b/bdk_core/src/chain_data.rs
@@ -1,0 +1,142 @@
+use crate::sparse_chain::{self, ChainIndex, ChainIndexExtension};
+use bitcoin::{hashes::Hash, BlockHash, OutPoint, TxOut, Txid};
+
+/// Represents the height in which a transaction is confirmed at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(crate = "serde_crate")
+)]
+pub enum TxHeight {
+    Confirmed(u32),
+    Unconfirmed,
+}
+
+impl Default for TxHeight {
+    fn default() -> Self {
+        Self::Unconfirmed
+    }
+}
+
+impl core::fmt::Display for TxHeight {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Confirmed(h) => core::write!(f, "confirmed_at({})", h),
+            Self::Unconfirmed => core::write!(f, "unconfirmed"),
+        }
+    }
+}
+
+impl From<Option<u32>> for TxHeight {
+    fn from(opt: Option<u32>) -> Self {
+        match opt {
+            Some(h) => Self::Confirmed(h),
+            None => Self::Unconfirmed,
+        }
+    }
+}
+
+impl From<TxHeight> for Option<u32> {
+    fn from(height: TxHeight) -> Self {
+        match height {
+            TxHeight::Confirmed(h) => Some(h),
+            TxHeight::Unconfirmed => None,
+        }
+    }
+}
+
+impl TxHeight {
+    pub fn is_confirmed(&self) -> bool {
+        matches!(self, Self::Confirmed(_))
+    }
+}
+
+/// Block height and timestamp in which a transaction is confirmed in.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Copy, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(crate = "serde_crate")
+)]
+pub struct ConfirmationTime {
+    pub height: TxHeight,
+    pub time: Option<u64>,
+}
+
+impl ConfirmationTime {
+    pub fn is_confirmed(&self) -> bool {
+        self.height.is_confirmed()
+    }
+}
+
+/// A reference to a block in the cannonical chain.
+#[derive(Debug, Clone, PartialEq, Eq, Copy, PartialOrd, Ord)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(crate = "serde_crate")
+)]
+pub struct BlockId {
+    /// The height the block was confirmed at
+    pub height: u32,
+    /// The hash of the block
+    pub hash: BlockHash,
+}
+
+impl Default for BlockId {
+    fn default() -> Self {
+        Self {
+            height: Default::default(),
+            hash: BlockHash::from_inner([0u8; 32]),
+        }
+    }
+}
+
+impl From<(u32, BlockHash)> for BlockId {
+    fn from((height, hash): (u32, BlockHash)) -> Self {
+        Self { height, hash }
+    }
+}
+
+impl From<BlockId> for (u32, BlockHash) {
+    fn from(block_id: BlockId) -> Self {
+        (block_id.height, block_id.hash)
+    }
+}
+
+impl From<(&u32, &BlockHash)> for BlockId {
+    fn from((height, hash): (&u32, &BlockHash)) -> Self {
+        Self {
+            height: *height,
+            hash: *hash,
+        }
+    }
+}
+
+/// A `TxOut` with as much data as we can retreive about it
+#[derive(Debug, Clone, PartialEq)]
+pub struct FullTxOut<E> {
+    pub outpoint: OutPoint,
+    pub txout: TxOut,
+    pub chain_index: sparse_chain::ChainIndex<E>,
+    pub spent_by: Option<Txid>,
+}
+
+/// A wrapped `u64` for use as a [`ChainIndexExtension`](crate::sparse_chain::ChainIndexExtension)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
+pub struct Timestamp(pub u64);
+
+impl ChainIndexExtension for Timestamp {
+    const MIN: Self = Timestamp(u64::MIN);
+    const MAX: Self = Timestamp(u64::MAX);
+}
+
+impl From<ConfirmationTime> for ChainIndex<Option<Timestamp>> {
+    fn from(ct: ConfirmationTime) -> Self {
+        ChainIndex {
+            height: ct.height,
+            extension: ct.time.map(Timestamp),
+        }
+    }
+}

--- a/bdk_core/src/chain_graph.rs
+++ b/bdk_core/src/chain_graph.rs
@@ -4,15 +4,24 @@ use core::fmt::Debug;
 use crate::{
     sparse_chain::{self, SparseChain},
     tx_graph::TxGraph,
-    BlockId,
+    BlockId, Timestamp,
 };
 
-pub type TimestampedChainGraph = ChainGraph<Option<u64>>;
+pub type TimestampedChainGraph = ChainGraph<Timestamp>;
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct ChainGraph<E = ()> {
     chain: SparseChain<E>,
     graph: TxGraph,
+}
+
+impl<E> Default for ChainGraph<E> {
+    fn default() -> Self {
+        Self {
+            chain: Default::default(),
+            graph: Default::default(),
+        }
+    }
 }
 
 impl<E: sparse_chain::ChainIndexExtension> ChainGraph<E> {

--- a/bdk_core/src/chain_graph.rs
+++ b/bdk_core/src/chain_graph.rs
@@ -2,20 +2,20 @@ use bitcoin::{OutPoint, Transaction, TxOut, Txid};
 use core::fmt::Debug;
 
 use crate::{
-    sparse_chain::{self, SparseChain},
+    sparse_chain::{self, ChainIndex, SparseChain},
     tx_graph::TxGraph,
-    BlockId, Timestamp,
+    BlockId, ConfirmationTime, TxHeight,
 };
 
-pub type TimestampedChainGraph = ChainGraph<Timestamp>;
+pub type TimestampedChainGraph = ChainGraph<ConfirmationTime>;
 
 #[derive(Clone, Debug)]
-pub struct ChainGraph<E = ()> {
-    chain: SparseChain<E>,
+pub struct ChainGraph<I: ChainIndex = TxHeight> {
+    chain: SparseChain<I>,
     graph: TxGraph,
 }
 
-impl<E> Default for ChainGraph<E> {
+impl<I: ChainIndex> Default for ChainGraph<I> {
     fn default() -> Self {
         Self {
             chain: Default::default(),
@@ -24,42 +24,29 @@ impl<E> Default for ChainGraph<E> {
     }
 }
 
-impl<E: sparse_chain::ChainIndexExtension> ChainGraph<E> {
-    pub fn insert_tx<I>(
+impl<I: sparse_chain::ChainIndex> ChainGraph<I> {
+    pub fn insert_tx(
         &mut self,
         tx: Transaction,
         index: I,
-    ) -> Result<bool, sparse_chain::InsertTxErr>
-    where
-        I: Into<sparse_chain::ChainIndex<E>>,
-    {
+    ) -> Result<bool, sparse_chain::InsertTxErr> {
         let changed = self.chain.insert_tx(tx.txid(), index)?;
         self.graph.insert_tx(&tx);
         Ok(changed)
     }
 
-    pub fn insert_output<I>(
+    pub fn insert_output(
         &mut self,
         outpoint: OutPoint,
         txout: TxOut,
         index: I,
-    ) -> Result<bool, sparse_chain::InsertTxErr>
-    where
-        I: Into<sparse_chain::ChainIndex<E>>,
-    {
+    ) -> Result<bool, sparse_chain::InsertTxErr> {
         let changed = self.chain.insert_tx(outpoint.txid, index)?;
         self.graph.insert_txout(outpoint, txout);
         Ok(changed)
     }
 
-    pub fn insert_txid<I>(
-        &mut self,
-        txid: Txid,
-        index: I,
-    ) -> Result<bool, sparse_chain::InsertTxErr>
-    where
-        I: Into<sparse_chain::ChainIndex<E>>,
-    {
+    pub fn insert_txid(&mut self, txid: Txid, index: I) -> Result<bool, sparse_chain::InsertTxErr> {
         self.chain.insert_tx(txid, index)
     }
 
@@ -70,7 +57,7 @@ impl<E: sparse_chain::ChainIndexExtension> ChainGraph<E> {
         self.chain.insert_checkpoint(block_id)
     }
 
-    pub fn chain(&self) -> &SparseChain<E> {
+    pub fn chain(&self) -> &SparseChain<I> {
         &self.chain
     }
 
@@ -81,7 +68,7 @@ impl<E: sparse_chain::ChainIndexExtension> ChainGraph<E> {
     pub fn apply_update(
         &mut self,
         update: &Self,
-    ) -> Result<sparse_chain::ChangeSet<E>, sparse_chain::UpdateFailure<E>> {
+    ) -> Result<sparse_chain::ChangeSet<I>, sparse_chain::UpdateFailure<I>> {
         let changeset = self.chain.determine_changeset(update.chain())?;
         changeset
             .tx_additions()

--- a/bdk_core/src/chain_graph.rs
+++ b/bdk_core/src/chain_graph.rs
@@ -2,15 +2,15 @@ use bitcoin::{OutPoint, Transaction, TxOut, Txid};
 use core::fmt::Debug;
 
 use crate::{
-    sparse_chain::{self, ChainIndex, SparseChain},
+    sparse_chain::{self, SparseChain},
     tx_graph::TxGraph,
-    BlockId, ConfirmationTime, TxHeight,
+    BlockId, ChainIndex, ConfirmationTime, TxHeight,
 };
 
 pub type TimestampedChainGraph = ChainGraph<ConfirmationTime>;
 
 #[derive(Clone, Debug)]
-pub struct ChainGraph<I: ChainIndex = TxHeight> {
+pub struct ChainGraph<I = TxHeight> {
     chain: SparseChain<I>,
     graph: TxGraph,
 }
@@ -24,7 +24,7 @@ impl<I: ChainIndex> Default for ChainGraph<I> {
     }
 }
 
-impl<I: sparse_chain::ChainIndex> ChainGraph<I> {
+impl<I: ChainIndex> ChainGraph<I> {
     pub fn insert_tx(
         &mut self,
         tx: Transaction,

--- a/bdk_core/src/chain_graph.rs
+++ b/bdk_core/src/chain_graph.rs
@@ -6,6 +6,8 @@ use crate::{
     SparseChain, TxGraph, UpdateFailure,
 };
 
+pub type TimestampedChainGraph = ChainGraph<Option<u64>>;
+
 #[derive(Clone, Debug, Default)]
 pub struct ChainGraph<E = ()> {
     chain: SparseChain<E>,

--- a/bdk_core/src/lib.rs
+++ b/bdk_core/src/lib.rs
@@ -1,16 +1,15 @@
 #![no_std]
 pub use alloc::{boxed::Box, vec::Vec};
 pub use bitcoin;
-use bitcoin::{hashes::Hash, BlockHash, TxOut};
 mod chain_graph;
 pub use chain_graph::*;
 mod spk_tracker;
 pub use spk_tracker::*;
-mod sparse_chain;
-pub use sparse_chain::*;
-mod tx_graph;
-pub use tx_graph::*;
+mod chain_data;
 pub mod coin_select;
+pub mod sparse_chain;
+pub mod tx_graph;
+pub use chain_data::*;
 #[cfg(feature = "miniscript")]
 mod keychain_tracker;
 #[cfg(feature = "miniscript")]
@@ -61,121 +60,8 @@ pub mod collections {
     pub use core::ops::Bound;
 }
 
-/// Represents the height in which a transaction is confirmed at.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
-pub enum TxHeight {
-    Confirmed(u32),
-    Unconfirmed,
-}
-
-impl Default for TxHeight {
-    fn default() -> Self {
-        Self::Unconfirmed
-    }
-}
-
-impl core::fmt::Display for TxHeight {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::Confirmed(h) => core::write!(f, "confirmed_at({})", h),
-            Self::Unconfirmed => core::write!(f, "unconfirmed"),
-        }
-    }
-}
-
-impl From<Option<u32>> for TxHeight {
-    fn from(opt: Option<u32>) -> Self {
-        match opt {
-            Some(h) => Self::Confirmed(h),
-            None => Self::Unconfirmed,
-        }
-    }
-}
-
-impl From<TxHeight> for Option<u32> {
-    fn from(height: TxHeight) -> Self {
-        match height {
-            TxHeight::Confirmed(h) => Some(h),
-            TxHeight::Unconfirmed => None,
-        }
-    }
-}
-
-impl TxHeight {
-    pub fn is_confirmed(&self) -> bool {
-        matches!(self, Self::Confirmed(_))
-    }
-}
-
-/// Block height and timestamp in which a transaction is confirmed in.
-#[derive(Debug, Clone, PartialEq, Eq, Default, Copy, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
-pub struct ConfirmationTime {
-    pub height: TxHeight,
-    pub time: Option<u64>,
-}
-
-impl ConfirmationTime {
-    pub fn is_confirmed(&self) -> bool {
-        self.height.is_confirmed()
-    }
-}
-
-/// A reference to a block in the cannonical chain.
-#[derive(Debug, Clone, PartialEq, Eq, Copy, PartialOrd, Ord)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
-pub struct BlockId {
-    /// The height the block was confirmed at
-    pub height: u32,
-    /// The hash of the block
-    pub hash: BlockHash,
-}
-
-impl Default for BlockId {
-    fn default() -> Self {
-        Self {
-            height: Default::default(),
-            hash: BlockHash::from_inner([0u8; 32]),
-        }
-    }
-}
-
-impl From<(u32, BlockHash)> for BlockId {
-    fn from((height, hash): (u32, BlockHash)) -> Self {
-        Self { height, hash }
-    }
-}
-
-impl From<BlockId> for (u32, BlockHash) {
-    fn from(block_id: BlockId) -> Self {
-        (block_id.height, block_id.hash)
-    }
-}
-
-impl From<(&u32, &BlockHash)> for BlockId {
-    fn from((height, hash): (&u32, &BlockHash)) -> Self {
-        Self {
-            height: *height,
-            hash: *hash,
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum PrevOuts {
-    Coinbase,
-    Spend(Vec<TxOut>),
-}
+// #[derive(Clone, Debug, PartialEq)]
+// pub enum PrevOuts {
+//     Coinbase,
+//     Spend(Vec<TxOut>),
+// }

--- a/bdk_core/src/lib.rs
+++ b/bdk_core/src/lib.rs
@@ -1,18 +1,18 @@
 #![no_std]
 pub use alloc::{boxed::Box, vec::Vec};
 pub use bitcoin;
-mod chain_graph;
 use bitcoin::TxOut;
+mod chain_graph;
 pub use chain_graph::*;
 mod spk_tracker;
 pub use spk_tracker::*;
 mod chain_data;
-pub mod coin_select;
-pub mod sparse_chain;
-pub mod tx_graph;
 pub use chain_data::*;
+pub mod coin_select;
 #[cfg(feature = "miniscript")]
 mod keychain_tracker;
+pub mod sparse_chain;
+pub mod tx_graph;
 #[cfg(feature = "miniscript")]
 pub use keychain_tracker::*;
 #[cfg(feature = "miniscript")]

--- a/bdk_core/src/lib.rs
+++ b/bdk_core/src/lib.rs
@@ -2,6 +2,7 @@
 pub use alloc::{boxed::Box, vec::Vec};
 pub use bitcoin;
 mod chain_graph;
+use bitcoin::TxOut;
 pub use chain_graph::*;
 mod spk_tracker;
 pub use spk_tracker::*;
@@ -60,8 +61,8 @@ pub mod collections {
     pub use core::ops::Bound;
 }
 
-// #[derive(Clone, Debug, PartialEq)]
-// pub enum PrevOuts {
-//     Coinbase,
-//     Spend(Vec<TxOut>),
-// }
+#[derive(Clone, Debug, PartialEq)]
+pub enum PrevOuts {
+    Coinbase,
+    Spend(Vec<TxOut>),
+}

--- a/bdk_core/src/lib.rs
+++ b/bdk_core/src/lib.rs
@@ -36,23 +36,97 @@ extern crate std;
 #[cfg(all(not(feature = "std"), feature = "hashbrown"))]
 extern crate hashbrown;
 
-/// Block height and timestamp of a block
+// When no-std use `alloc`'s Hash collections. This is activated by default
+#[cfg(all(not(feature = "std"), not(feature = "hashbrown")))]
+pub mod collections {
+    #![allow(dead_code)]
+    pub type HashSet<K> = alloc::collections::BTreeSet<K>;
+    pub type HashMap<K, V> = alloc::collections::BTreeMap<K, V>;
+    pub use alloc::collections::*;
+}
+
+// When we have std use `std`'s all collections
+#[cfg(all(feature = "std", not(feature = "hashbrown")))]
+pub mod collections {
+    pub use std::collections::*;
+}
+
+// With special feature `hashbrown` use `hashbrown`'s hash collections, and else from `alloc`.
+#[cfg(feature = "hashbrown")]
+pub mod collections {
+    #![allow(dead_code)]
+    pub type HashSet<K> = hashbrown::HashSet<K>;
+    pub type HashMap<K, V> = hashbrown::HashMap<K, V>;
+    pub use alloc::collections::*;
+    pub use core::ops::Bound;
+}
+
+/// Represents the height in which a transaction is confirmed at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(crate = "serde_crate")
+)]
+pub enum TxHeight {
+    Confirmed(u32),
+    Unconfirmed,
+}
+
+impl Default for TxHeight {
+    fn default() -> Self {
+        Self::Unconfirmed
+    }
+}
+
+impl core::fmt::Display for TxHeight {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Confirmed(h) => core::write!(f, "confirmed_at({})", h),
+            Self::Unconfirmed => core::write!(f, "unconfirmed"),
+        }
+    }
+}
+
+impl From<Option<u32>> for TxHeight {
+    fn from(opt: Option<u32>) -> Self {
+        match opt {
+            Some(h) => Self::Confirmed(h),
+            None => Self::Unconfirmed,
+        }
+    }
+}
+
+impl From<TxHeight> for Option<u32> {
+    fn from(height: TxHeight) -> Self {
+        match height {
+            TxHeight::Confirmed(h) => Some(h),
+            TxHeight::Unconfirmed => None,
+        }
+    }
+}
+
+impl TxHeight {
+    pub fn is_confirmed(&self) -> bool {
+        matches!(self, Self::Confirmed(_))
+    }
+}
+
+/// Block height and timestamp in which a transaction is confirmed in.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Copy, PartialOrd, Ord)]
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
     serde(crate = "serde_crate")
 )]
-pub struct BlockTime {
-    /// confirmation block height
-    pub height: u32,
-    /// confirmation block timestamp
-    pub time: u64,
+pub struct ConfirmationTime {
+    pub height: TxHeight,
+    pub time: Option<u64>,
 }
 
-impl From<(u32, u64)> for BlockTime {
-    fn from((height, time): (u32, u64)) -> Self {
-        Self { height, time }
+impl ConfirmationTime {
+    pub fn is_confirmed(&self) -> bool {
+        self.height.is_confirmed()
     }
 }
 
@@ -98,31 +172,6 @@ impl From<(&u32, &BlockHash)> for BlockId {
             hash: *hash,
         }
     }
-}
-
-// When no-std use `alloc`'s Hash collections. This is activated by default
-#[cfg(all(not(feature = "std"), not(feature = "hashbrown")))]
-pub mod collections {
-    #![allow(dead_code)]
-    pub type HashSet<K> = alloc::collections::BTreeSet<K>;
-    pub type HashMap<K, V> = alloc::collections::BTreeMap<K, V>;
-    pub use alloc::collections::*;
-}
-
-// When we have std use `std`'s all collections
-#[cfg(all(feature = "std", not(feature = "hashbrown")))]
-pub mod collections {
-    pub use std::collections::*;
-}
-
-// With special feature `hashbrown` use `hashbrown`'s hash collections, and else from `alloc`.
-#[cfg(feature = "hashbrown")]
-pub mod collections {
-    #![allow(dead_code)]
-    pub type HashSet<K> = hashbrown::HashSet<K>;
-    pub type HashMap<K, V> = hashbrown::HashMap<K, V>;
-    pub use alloc::collections::*;
-    pub use core::ops::Bound;
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/bdk_core/src/sparse_chain.rs
+++ b/bdk_core/src/sparse_chain.rs
@@ -3,13 +3,14 @@ use core::{
     ops::{Bound, RangeBounds},
 };
 
-use crate::{
-    collections::*, tx_graph::TxGraph, BlockId, ConfirmationTime, FullTxOut, TxHeight, Vec,
-};
+use crate::{collections::*, tx_graph::TxGraph, BlockId, FullTxOut, Timestamp, TxHeight, Vec};
 use bitcoin::{hashes::Hash, BlockHash, OutPoint, Txid};
 
-/// A [`SparseChain`] in which the [`ChainIndex`] is extended by a timestamp.
-pub type TimestampedSparseChain = SparseChain<Option<u64>>;
+/// A [`SparseChain`] in which the [`ChainIndex`] is extended by a [`Timestamp`].
+pub type TimestampedSparseChain = SparseChain<Timestamp>;
+
+/// A [`ChainIndex`] which is extended by a [`Timestamp`].
+pub type TimestampedChainIndex = ChainIndex<Timestamp>;
 
 /// This is a non-monotone structure that tracks relevant [`Txid`]s that are ordered by
 /// [`ChainIndex`].
@@ -683,11 +684,6 @@ pub trait ChainIndexExtension:
     const MAX: Self;
 }
 
-impl<E: ChainIndexExtension> ChainIndexExtension for Option<E> {
-    const MIN: Self = None;
-    const MAX: Self = Some(E::MAX);
-}
-
 impl ChainIndexExtension for () {
     const MIN: Self = ();
     const MAX: Self = ();
@@ -716,15 +712,6 @@ impl<E: ChainIndexExtension, I: Into<E>> From<(TxHeight, I)> for ChainIndex<E> {
         Self {
             height,
             extension: extension.into(),
-        }
-    }
-}
-
-impl From<ConfirmationTime> for ChainIndex<Option<u64>> {
-    fn from(conf: ConfirmationTime) -> Self {
-        Self {
-            height: conf.height,
-            extension: conf.time,
         }
     }
 }

--- a/bdk_core/src/sparse_chain.rs
+++ b/bdk_core/src/sparse_chain.rs
@@ -108,13 +108,15 @@ impl<I: ChainIndex + core::fmt::Debug> std::error::Error for UpdateFailure<I> {}
 impl<I: ChainIndex> SparseChain<I> {
     /// Creates a new chain from a list of block hashes and heights. The caller must guarantee they are in the same
     /// chain.
-    pub fn from_checkpoints<B, C>(checkpoints: C) -> Self
+    pub fn from_checkpoints<C>(checkpoints: C) -> Self
     where
-        B: Into<(u32, BlockHash)>,
-        C: IntoIterator<Item = B>,
+        C: IntoIterator<Item = BlockId>,
     {
         let mut chain = Self::default();
-        chain.checkpoints = checkpoints.into_iter().map(|block| block.into()).collect();
+        chain.checkpoints = checkpoints
+            .into_iter()
+            .map(|block_id| block_id.into())
+            .collect();
         chain
     }
 

--- a/bdk_core/src/spk_tracker.rs
+++ b/bdk_core/src/spk_tracker.rs
@@ -1,8 +1,8 @@
 use crate::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    sparse_chain::{self, SparseChain},
+    sparse_chain::SparseChain,
     tx_graph::TxGraph,
-    FullTxOut,
+    ChainIndex, FullTxOut,
 };
 use bitcoin::{self, OutPoint, Script, Transaction, TxOut, Txid};
 use core::ops::RangeBounds;
@@ -71,7 +71,7 @@ impl<I: Clone + Ord> SpkTracker<I> {
             .map(|(op, (index, txout))| (index.clone(), *op, txout))
     }
 
-    pub fn iter_unspent<'a, C: sparse_chain::ChainIndex>(
+    pub fn iter_unspent<'a, C: ChainIndex>(
         &'a self,
         chain: &'a SparseChain<C>,
         graph: &'a TxGraph,

--- a/bdk_core/src/spk_tracker.rs
+++ b/bdk_core/src/spk_tracker.rs
@@ -1,10 +1,11 @@
-use core::ops::RangeBounds;
-
 use crate::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    ChainIndexExtension, FullTxOut, SparseChain, TxGraph,
+    sparse_chain::{self, SparseChain},
+    tx_graph::TxGraph,
+    FullTxOut,
 };
 use bitcoin::{self, OutPoint, Script, Transaction, TxOut, Txid};
+use core::ops::RangeBounds;
 
 /// A *script pubkey* tracker.
 ///
@@ -70,7 +71,7 @@ impl<I: Clone + Ord> SpkTracker<I> {
             .map(|(op, (index, txout))| (index.clone(), *op, txout))
     }
 
-    pub fn iter_unspent<'a, E: ChainIndexExtension>(
+    pub fn iter_unspent<'a, E: sparse_chain::ChainIndexExtension>(
         &'a self,
         chain: &'a SparseChain<E>,
         graph: &'a TxGraph,

--- a/bdk_core/src/spk_tracker.rs
+++ b/bdk_core/src/spk_tracker.rs
@@ -71,11 +71,11 @@ impl<I: Clone + Ord> SpkTracker<I> {
             .map(|(op, (index, txout))| (index.clone(), *op, txout))
     }
 
-    pub fn iter_unspent<'a, E: sparse_chain::ChainIndexExtension>(
+    pub fn iter_unspent<'a, C: sparse_chain::ChainIndex>(
         &'a self,
-        chain: &'a SparseChain<E>,
+        chain: &'a SparseChain<C>,
         graph: &'a TxGraph,
-    ) -> impl DoubleEndedIterator<Item = (I, FullTxOut<E>)> + '_ {
+    ) -> impl DoubleEndedIterator<Item = (I, FullTxOut<C>)> + '_ {
         self.iter_txout().filter_map(|(index, outpoint, txout)| {
             if !chain.is_unspent(graph, outpoint)? {
                 return None;

--- a/bdk_core/tests/test_sparse_chain.rs
+++ b/bdk_core/tests/test_sparse_chain.rs
@@ -1,7 +1,7 @@
 use bdk_core::{
     collections::{BTreeSet, Bound},
     sparse_chain::*,
-    BlockId, TxHeight,
+    BlockId, ChainIndex, TxHeight,
 };
 use bitcoin::{hashes::Hash, Txid};
 

--- a/bdk_core/tests/test_sparse_chain.rs
+++ b/bdk_core/tests/test_sparse_chain.rs
@@ -3,14 +3,14 @@ use bdk_core::{
     sparse_chain::*,
     BlockId, TxHeight,
 };
-use bitcoin::{hashes::Hash, BlockHash, Txid};
+use bitcoin::{hashes::Hash, Txid};
 
 macro_rules! chain {
     ($([$($tt:tt)*]),*) => { chain!( checkpoints: [$([$($tt)*]),*] ) };
     (checkpoints: $($tail:tt)*) => { chain!( index: TxHeight, checkpoints: $($tail)*) };
     (index: $ind:ty, checkpoints: [ $([$height:expr, $block_hash:expr]),* ] $(,txids: [$(($txid:expr, $tx_height:expr)),*])?) => {{
         #[allow(unused_mut)]
-        let mut chain = SparseChain::<$ind>::from_checkpoints::<(u32, BlockHash), _>([$(($height, $block_hash)),*]);
+        let mut chain = SparseChain::<$ind>::from_checkpoints([$(($height, $block_hash).into()),*]);
 
         $(
             $(
@@ -568,8 +568,7 @@ fn checkpoint_limit_is_respected() {
 
 #[test]
 fn range_txids_by_height() {
-    let mut chain =
-        SparseChain::<TestIndex>::from_checkpoints([(1, h!("block 1")), (2, h!("block 2"))]);
+    let mut chain = chain!(index: TestIndex, checkpoints: [[1, h!("block 1")], [2, h!("block 2")]]);
 
     let txids: [(TestIndex, Txid); 4] = [
         (
@@ -630,8 +629,7 @@ fn range_txids_by_height() {
 
 #[test]
 fn range_txids_by_index() {
-    let mut chain =
-        SparseChain::<TestIndex>::from_checkpoints([(1, h!("block 1")), (2, h!("block 2"))]);
+    let mut chain = chain!(index: TestIndex, checkpoints: [[1, h!("block 1")],[2, h!("block 2")]]);
 
     let txids: [(TestIndex, Txid); 4] = [
         (TestIndex(TxHeight::Confirmed(1), u32::MIN), h!("tx 1 min")),

--- a/bdk_core/tests/test_sparse_chain.rs
+++ b/bdk_core/tests/test_sparse_chain.rs
@@ -367,7 +367,7 @@ fn cannot_change_ext_index_of_confirmed_tx() {
     assert_eq!(
         chain1.determine_changeset(&chain2),
         Err(UpdateFailure::InconsistentTx {
-            inconsistent_txid: h!("tx1"),
+            inconsistent_txid: h!("tx0"),
             original_index: (TxHeight::Confirmed(1), 10).into(),
             update_index: (TxHeight::Confirmed(1), 20).into(),
         }),

--- a/bdk_core/tests/test_sparse_chain.rs
+++ b/bdk_core/tests/test_sparse_chain.rs
@@ -58,24 +58,16 @@ macro_rules! changeset {
 pub struct TestIndex(TxHeight, u32);
 
 impl ChainIndex for TestIndex {
-    type Extension = u32;
-    const EXTENSION_MIN: u32 = u32::MIN;
-    const EXTENSION_MAX: u32 = u32::MAX;
-
     fn height(&self) -> TxHeight {
         self.0
     }
 
-    fn extension(&self) -> Self::Extension {
-        self.1
+    fn max_ord_of_height(height: TxHeight) -> Self {
+        Self(height, u32::MAX)
     }
 
-    fn into_ordered_key(self) -> (TxHeight, Self::Extension) {
-        (self.0, self.1)
-    }
-
-    fn from_ordered_key(key: (TxHeight, Self::Extension)) -> Self {
-        Self(key.0, key.1)
+    fn min_ord_of_height(height: TxHeight) -> Self {
+        Self(height, u32::MIN)
     }
 }
 
@@ -608,7 +600,7 @@ fn range_txids_by_height() {
         chain
             .range_txids_by_height(TxHeight::Confirmed(1)..)
             .collect::<Vec<_>>(),
-        txids.iter().cloned().collect::<Vec<_>>(),
+        txids.iter().collect::<Vec<_>>(),
     );
 
     // exclusive start
@@ -616,7 +608,7 @@ fn range_txids_by_height() {
         chain
             .range_txids_by_height((Bound::Excluded(TxHeight::Confirmed(1)), Bound::Unbounded,))
             .collect::<Vec<_>>(),
-        txids[2..].iter().cloned().collect::<Vec<_>>(),
+        txids[2..].iter().collect::<Vec<_>>(),
     );
 
     // inclusive end
@@ -624,7 +616,7 @@ fn range_txids_by_height() {
         chain
             .range_txids_by_height((Bound::Unbounded, Bound::Included(TxHeight::Confirmed(2))))
             .collect::<Vec<_>>(),
-        txids[..4].iter().cloned().collect::<Vec<_>>(),
+        txids[..4].iter().collect::<Vec<_>>(),
     );
 
     // exclusive end
@@ -632,7 +624,7 @@ fn range_txids_by_height() {
         chain
             .range_txids_by_height(..TxHeight::Confirmed(2))
             .collect::<Vec<_>>(),
-        txids[..2].iter().cloned().collect::<Vec<_>>(),
+        txids[..2].iter().collect::<Vec<_>>(),
     );
 }
 
@@ -658,13 +650,13 @@ fn range_txids_by_index() {
         chain
             .range_txids_by_index(TestIndex(TxHeight::Confirmed(1), u32::MIN)..)
             .collect::<Vec<_>>(),
-        txids.iter().cloned().collect::<Vec<_>>(),
+        txids.iter().collect::<Vec<_>>(),
     );
     assert_eq!(
         chain
             .range_txids_by_index(TestIndex(TxHeight::Confirmed(1), u32::MAX)..)
             .collect::<Vec<_>>(),
-        txids[1..].iter().cloned().collect::<Vec<_>>(),
+        txids[1..].iter().collect::<Vec<_>>(),
     );
 
     // exclusive start
@@ -675,7 +667,7 @@ fn range_txids_by_index() {
                 Bound::Unbounded
             ))
             .collect::<Vec<_>>(),
-        txids[1..].iter().cloned().collect::<Vec<_>>(),
+        txids[1..].iter().collect::<Vec<_>>(),
     );
     assert_eq!(
         chain
@@ -684,7 +676,7 @@ fn range_txids_by_index() {
                 Bound::Unbounded
             ))
             .collect::<Vec<_>>(),
-        txids[2..].iter().cloned().collect::<Vec<_>>(),
+        txids[2..].iter().collect::<Vec<_>>(),
     );
 
     // inclusive end
@@ -695,7 +687,7 @@ fn range_txids_by_index() {
                 Bound::Included(TestIndex(TxHeight::Confirmed(2), u32::MIN))
             ))
             .collect::<Vec<_>>(),
-        txids[..3].iter().cloned().collect::<Vec<_>>(),
+        txids[..3].iter().collect::<Vec<_>>(),
     );
     assert_eq!(
         chain
@@ -704,7 +696,7 @@ fn range_txids_by_index() {
                 Bound::Included(TestIndex(TxHeight::Confirmed(2), u32::MAX))
             ))
             .collect::<Vec<_>>(),
-        txids[..4].iter().cloned().collect::<Vec<_>>(),
+        txids[..4].iter().collect::<Vec<_>>(),
     );
 
     // exclusive end
@@ -712,13 +704,13 @@ fn range_txids_by_index() {
         chain
             .range_txids_by_index(..TestIndex(TxHeight::Confirmed(2), u32::MIN))
             .collect::<Vec<_>>(),
-        txids[..2].iter().cloned().collect::<Vec<_>>(),
+        txids[..2].iter().collect::<Vec<_>>(),
     );
     assert_eq!(
         chain
             .range_txids_by_index(..TestIndex(TxHeight::Confirmed(2), u32::MAX))
             .collect::<Vec<_>>(),
-        txids[..3].iter().cloned().collect::<Vec<_>>(),
+        txids[..3].iter().collect::<Vec<_>>(),
     );
 }
 
@@ -743,7 +735,7 @@ fn range_txids() {
                 .range_txids((TxHeight::Unconfirmed, *txid)..)
                 .map(|(_, txid)| txid)
                 .collect::<Vec<_>>(),
-            txids.range(*txid..).cloned().collect::<Vec<_>>(),
+            txids.range(*txid..).collect::<Vec<_>>(),
             "range with inclusive start should succeed"
         );
 
@@ -757,7 +749,6 @@ fn range_txids() {
                 .collect::<Vec<_>>(),
             txids
                 .range((Bound::Excluded(*txid), Bound::Unbounded,))
-                .cloned()
                 .collect::<Vec<_>>(),
             "range with exclusive start should succeed"
         );
@@ -767,7 +758,7 @@ fn range_txids() {
                 .range_txids(..(TxHeight::Unconfirmed, *txid))
                 .map(|(_, txid)| txid)
                 .collect::<Vec<_>>(),
-            txids.range(..*txid).cloned().collect::<Vec<_>>(),
+            txids.range(..*txid).collect::<Vec<_>>(),
             "range with exclusive end should succeed"
         );
 
@@ -781,7 +772,6 @@ fn range_txids() {
                 .collect::<Vec<_>>(),
             txids
                 .range((Bound::Included(*txid), Bound::Unbounded,))
-                .cloned()
                 .collect::<Vec<_>>(),
             "range with inclusive end should succeed"
         );

--- a/bdk_core_example/src/main.rs
+++ b/bdk_core_example/src/main.rs
@@ -10,7 +10,7 @@ use bdk_core::{
     coin_select::{coin_select_bnb, CoinSelector, CoinSelectorOpt, WeightedValue},
     descriptor_into_script_iter,
     miniscript::{Descriptor, DescriptorPublicKey},
-    ChainGraph, DescriptorExt, KeychainTracker,
+    ChainGraph, DescriptorExt, KeychainTracker, TimestampedChainGraph,
 };
 use bdk_esplora::ureq::{ureq, Client};
 use clap::{Parser, Subcommand};
@@ -430,7 +430,7 @@ fn main() -> anyhow::Result<()> {
 pub fn fully_sync(
     client: &Client,
     tracker: &mut KeychainTracker<Keychain>,
-    chain: &mut ChainGraph<()>,
+    chain: &mut TimestampedChainGraph,
 ) -> anyhow::Result<()> {
     let start = std::time::Instant::now();
     let mut active_indexes = vec![];

--- a/bdk_core_example/src/main.rs
+++ b/bdk_core_example/src/main.rs
@@ -10,7 +10,7 @@ use bdk_core::{
     coin_select::{coin_select_bnb, CoinSelector, CoinSelectorOpt, WeightedValue},
     descriptor_into_script_iter,
     miniscript::{Descriptor, DescriptorPublicKey},
-    ChainGraph, DescriptorExt, KeychainTracker, TimestampedChainGraph,
+    ChainGraph, ChainIndex, DescriptorExt, KeychainTracker, TimestampedChainGraph,
 };
 use bdk_esplora::ureq::{ureq, Client};
 use clap::{Parser, Subcommand};
@@ -193,7 +193,7 @@ fn main() -> anyhow::Result<()> {
             let (confirmed, unconfirmed) = tracker.iter_unspent(chain.chain(), chain.graph()).fold(
                 (0, 0),
                 |(confirmed, unconfirmed), ((keychain, _), utxo)| {
-                    if utxo.chain_index.height.is_confirmed() || keychain == Keychain::Internal {
+                    if utxo.chain_index.is_confirmed() || keychain == Keychain::Internal {
                         (confirmed + utxo.txout.value, unconfirmed)
                     } else {
                         (confirmed, unconfirmed + utxo.txout.value)
@@ -258,10 +258,10 @@ fn main() -> anyhow::Result<()> {
                     candidates.sort_by_key(|(_, utxo)| utxo.txout.value)
                 }
                 CoinSelectionAlgo::OldestFirst => {
-                    candidates.sort_by_key(|(_, utxo)| utxo.chain_index.height)
+                    candidates.sort_by_key(|(_, utxo)| utxo.chain_index.height())
                 }
                 CoinSelectionAlgo::NewestFirst => {
-                    candidates.sort_by_key(|(_, utxo)| Reverse(utxo.chain_index.height))
+                    candidates.sort_by_key(|(_, utxo)| Reverse(utxo.chain_index.height()))
                 }
                 CoinSelectionAlgo::BranchAndBound => {}
             }

--- a/bdk_esplora/src/api.rs
+++ b/bdk_esplora/src/api.rs
@@ -40,11 +40,11 @@ pub struct TxStatus {
     pub block_time: Option<u64>,
 }
 
-impl From<TxStatus> for ConfirmationTime {
-    fn from(status: TxStatus) -> Self {
-        Self {
-            height: status.block_height.into(),
-            time: Timestamp(status.block_time.unwrap_or(0)),
+impl TxStatus {
+    pub fn into_confirmation_time(self, fallback_time: u64) -> ConfirmationTime {
+        ConfirmationTime {
+            height: self.block_height.into(),
+            time: Timestamp(self.block_time.unwrap_or(fallback_time)),
         }
     }
 }
@@ -91,8 +91,8 @@ impl Tx {
         }
     }
 
-    pub fn confirmation_time(&self) -> ConfirmationTime {
-        self.status.clone().into()
+    pub fn confirmation_time(&self, fallback_time: u64) -> ConfirmationTime {
+        self.status.clone().into_confirmation_time(fallback_time)
     }
 
     pub fn previous_outputs(&self) -> PrevOuts {

--- a/bdk_esplora/src/api.rs
+++ b/bdk_esplora/src/api.rs
@@ -6,7 +6,7 @@ use bdk_core::{
         BlockHash, OutPoint, PackedLockTime, Script, Sequence, Transaction, TxIn, TxOut, Txid,
         Witness,
     },
-    BlockId, ConfirmationTime, PrevOuts, Timestamp,
+    BlockId, ConfirmationTime, PrevOuts,
 };
 
 #[derive(serde::Deserialize, Clone, Debug)]
@@ -41,10 +41,10 @@ pub struct TxStatus {
 }
 
 impl TxStatus {
-    pub fn into_confirmation_time(self, fallback_time: u64) -> ConfirmationTime {
+    pub fn into_confirmation_time(self) -> ConfirmationTime {
         ConfirmationTime {
             height: self.block_height.into(),
-            time: Timestamp(self.block_time.unwrap_or(fallback_time)),
+            time: self.block_time,
         }
     }
 }
@@ -91,8 +91,8 @@ impl Tx {
         }
     }
 
-    pub fn confirmation_time(&self, fallback_time: u64) -> ConfirmationTime {
-        self.status.clone().into_confirmation_time(fallback_time)
+    pub fn confirmation_time(&self) -> ConfirmationTime {
+        self.status.clone().into_confirmation_time()
     }
 
     pub fn previous_outputs(&self) -> PrevOuts {

--- a/bdk_esplora/src/api.rs
+++ b/bdk_esplora/src/api.rs
@@ -42,9 +42,13 @@ pub struct TxStatus {
 
 impl TxStatus {
     pub fn into_confirmation_time(self) -> ConfirmationTime {
-        ConfirmationTime {
-            height: self.block_height.into(),
-            time: self.block_time,
+        if self.confirmed {
+            ConfirmationTime::Confirmed {
+                height: self.block_height.unwrap_or(0),
+                time: self.block_time.unwrap_or(0),
+            }
+        } else {
+            ConfirmationTime::Unconfirmed
         }
     }
 }

--- a/bdk_esplora/src/api.rs
+++ b/bdk_esplora/src/api.rs
@@ -6,7 +6,7 @@ use bdk_core::{
         BlockHash, OutPoint, PackedLockTime, Script, Sequence, Transaction, TxIn, TxOut, Txid,
         Witness,
     },
-    BlockId, ConfirmationTime, PrevOuts, TimestampedChainIndex,
+    BlockId, ConfirmationTime, PrevOuts, Timestamp,
 };
 
 #[derive(serde::Deserialize, Clone, Debug)]
@@ -44,16 +44,7 @@ impl From<TxStatus> for ConfirmationTime {
     fn from(status: TxStatus) -> Self {
         Self {
             height: status.block_height.into(),
-            time: status.block_time,
-        }
-    }
-}
-
-impl From<TxStatus> for TimestampedChainIndex {
-    fn from(status: TxStatus) -> Self {
-        Self {
-            height: status.block_height.into(),
-            extension: status.block_time,
+            time: Timestamp(status.block_time.unwrap_or(0)),
         }
     }
 }

--- a/bdk_esplora/src/ureq.rs
+++ b/bdk_esplora/src/ureq.rs
@@ -5,7 +5,8 @@ use bdk_core::{
         hashes::{hex::ToHex, sha256, Hash},
         BlockHash, Script, Transaction, Txid,
     },
-    BlockId, InsertCheckpointErr, InsertTxErr, TimestampedChainGraph,
+    sparse_chain::{InsertCheckpointErr, InsertTxErr},
+    BlockId, ConfirmationTime, TimestampedChainGraph,
 };
 use std::collections::{BTreeMap, BTreeSet};
 pub use ureq;
@@ -256,7 +257,9 @@ impl Client {
                     empty_scripts = 0;
                 }
                 for tx in related_txs {
-                    if let Err(err) = update.insert_tx(tx.to_tx(), tx.status) {
+                    if let Err(err) =
+                        update.insert_tx::<ConfirmationTime>(tx.to_tx(), tx.status.into())
+                    {
                         match err {
                             InsertTxErr::TxTooHigh => {
                                 /* Don't care about new transactions confirmed while syncing */

--- a/bdk_esplora/src/ureq.rs
+++ b/bdk_esplora/src/ureq.rs
@@ -256,10 +256,6 @@ impl Client {
                 })
                 .collect::<Vec<_>>();
 
-            let fallback_time = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("should obtain system time")
-                .as_secs();
             let n_handles = handles.len();
 
             for handle in handles {
@@ -271,8 +267,8 @@ impl Client {
                     empty_scripts = 0;
                 }
                 for tx in related_txs {
-                    if let Err(err) = update
-                        .insert_tx(tx.to_tx(), tx.status.into_confirmation_time(fallback_time))
+                    if let Err(err) =
+                        update.insert_tx(tx.to_tx(), tx.status.into_confirmation_time())
                     {
                         match err {
                             InsertTxErr::TxTooHigh => {


### PR DESCRIPTION
Changes:
* Introduce `ConfirmationTime` which replaces `BlockTime`.
* `ChainIndex` is now a trait (which `TxHeight` and `ConfirmationTime` implements.
* Add `SparseChain::range_txids_by_height()` with tests.
* Add comments and documentation.
* Esplora example now stores timestamp in `SparseChain`.