### PR TITLE
Use the new planning module

### DIFF
--- a/bdk_core/Cargo.toml
+++ b/bdk_core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 bitcoin = { version = "0.29" }
-miniscript = { git = "https://github.com/llfourn/rust-miniscript",  rev = "82ba3928cc594a7ddf2710e145862c89f7702bd3", optional = true }
+miniscript = { git = "https://github.com/afilini/rust-miniscript.git", rev = "632a365cc36bc55cfa142c372023eeb55533bb4d", optional = true }
 serde_crate = { package = "serde", version = "1", optional = true, features = ["derive"] }
 # Use hashbrown as a feature flag to have HashSet and HashMap from it.
 hashbrown = { version = "0.12.1" , optional = true }


### PR DESCRIPTION
Use the new planning module in the example

This PR adds a bit of new code because our version of the planning module in miniscript is a bit simpler, so we have to do more things here.

This also starts using PSBTs as a storage medium for signatures, to remove the need for a special "signatures container" struct which was present before.