### PR TITLE
Txgraph fixes

### DIFF
--- a/bdk_core/src/chain_data.rs
+++ b/bdk_core/src/chain_data.rs
@@ -164,5 +164,5 @@ pub struct FullTxOut<I> {
     pub outpoint: OutPoint,
     pub txout: TxOut,
     pub chain_index: I,
-    pub spent_by: Option<Txid>,
+    pub spent_by: Option<(I, Txid)>,
 }

--- a/bdk_core/src/chain_graph.rs
+++ b/bdk_core/src/chain_graph.rs
@@ -90,6 +90,13 @@ impl<I: ChainIndex> ChainGraph<I> {
     pub fn full_txout(&self, outpoint: OutPoint) -> Option<FullTxOut<I>> {
         self.chain.full_txout(&self.graph, outpoint)
     }
+
+    /// Finds the transaction in the chain that spends `outpoint` given the input/output
+    /// relationships in `graph`. Note that the transaction including `outpoint` does not need to be
+    /// in the `graph` or the `chain` for this to return `Some(_)`.
+    pub fn spent_by(&self, outpoint: OutPoint) -> Option<(&I, Txid)> {
+        self.chain.spent_by(&self.graph, outpoint)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/bdk_core/src/chain_graph.rs
+++ b/bdk_core/src/chain_graph.rs
@@ -39,7 +39,7 @@ impl<I: ChainIndex> ChainGraph<I> {
         index: I,
     ) -> Result<bool, sparse_chain::InsertTxErr> {
         let changed = self.chain.insert_tx(tx.txid(), index)?;
-        self.graph.insert_tx(&tx);
+        self.graph.insert_tx(tx);
         Ok(changed)
     }
 
@@ -70,9 +70,9 @@ impl<I: ChainIndex> ChainGraph<I> {
     }
 
     /// Applies a [`ChangeSet`] to the chain graph
-    pub fn apply_changeset(&mut self, changeset: &ChangeSet<I>) {
-        self.chain.apply_changeset(&changeset.chain);
-        self.graph.apply_additions(&changeset.graph);
+    pub fn apply_changeset(&mut self, changeset: ChangeSet<I>) {
+        self.chain.apply_changeset(changeset.chain);
+        self.graph.apply_additions(changeset.graph);
     }
 
     /// Applies the `update` chain graph. Note this is shorthand for calling [`determine_changeset`]
@@ -80,13 +80,10 @@ impl<I: ChainIndex> ChainGraph<I> {
     ///
     /// [`apply_changeset`]: Self::apply_changeset
     /// [`determine_changeset`]: Self::determine_changeset
-    pub fn apply_update(
-        &mut self,
-        update: &Self,
-    ) -> Result<ChangeSet<I>, sparse_chain::UpdateFailure<I>> {
-        let changeset = self.determine_changeset(update)?;
-        self.apply_changeset(&changeset);
-        Ok(changeset)
+    pub fn apply_update(&mut self, update: Self) -> Result<(), sparse_chain::UpdateFailure<I>> {
+        let changeset = self.determine_changeset(&update)?;
+        self.apply_changeset(changeset);
+        Ok(())
     }
 
     /// Get the full transaction output at an outpoint if it exists in the chain and the graph.

--- a/bdk_core/tests/test_chain_graph.rs
+++ b/bdk_core/tests/test_chain_graph.rs
@@ -1,0 +1,49 @@
+use bdk_core::{chain_graph::ChainGraph, TxHeight};
+use bitcoin::{OutPoint, PackedLockTime, Transaction, TxIn, TxOut};
+
+#[test]
+fn test_spent_by() {
+    let tx1 = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(0),
+        input: vec![],
+        output: vec![TxOut::default()],
+    };
+
+    let op = OutPoint {
+        txid: tx1.txid(),
+        vout: 0,
+    };
+
+    let tx2 = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(0),
+        input: vec![TxIn {
+            previous_output: op,
+            ..Default::default()
+        }],
+        output: vec![],
+    };
+    let tx3 = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(42),
+        input: vec![TxIn {
+            previous_output: op,
+            ..Default::default()
+        }],
+        output: vec![],
+    };
+
+    let mut cg1 = ChainGraph::default();
+    cg1.insert_tx(tx1, TxHeight::Unconfirmed).unwrap();
+    let mut cg2 = cg1.clone();
+    cg1.insert_tx(tx2.clone(), TxHeight::Unconfirmed).unwrap();
+    cg2.insert_tx(tx3.clone(), TxHeight::Unconfirmed).unwrap();
+    // put the these txs in the graph but not in chain. `spent_by` should return the one that was
+    // actually in the respective chain.
+    cg1.graph.insert_tx(tx3.clone());
+    cg2.graph.insert_tx(tx2.clone());
+
+    assert_eq!(cg1.spent_by(op), Some((&TxHeight::Unconfirmed, tx2.txid())));
+    assert_eq!(cg2.spent_by(op), Some((&TxHeight::Unconfirmed, tx3.txid())));
+}

--- a/bdk_core/tests/test_sparse_chain.rs
+++ b/bdk_core/tests/test_sparse_chain.rs
@@ -481,7 +481,7 @@ fn invalidation_but_no_connection() {
 fn checkpoint_limit_is_respected() {
     let mut chain1 = SparseChain::default();
     chain1
-        .apply_update(&chain!(
+        .apply_update(chain!(
             [1, h!("A")],
             [2, h!("B")],
             [3, h!("C")],
@@ -502,10 +502,10 @@ fn checkpoint_limit_is_respected() {
         .unwrap();
     assert_eq!(chain1.checkpoints().len(), 4);
 
-    assert_eq!(
-        chain1.apply_update(&chain!([6, h!("F")], [7, h!("G")])),
-        Ok(changeset!(checkpoints: [(7, Some(h!("G")))]))
-    );
+    let changeset = chain1.determine_changeset(&chain!([6, h!("F")], [7, h!("G")]));
+    assert_eq!(changeset, Ok(changeset!(checkpoints: [(7, Some(h!("G")))])));
+
+    chain1.apply_changeset(changeset.unwrap());
 
     assert_eq!(chain1.checkpoints().len(), 4);
 }

--- a/bdk_core/tests/test_tx_graph.rs
+++ b/bdk_core/tests/test_tx_graph.rs
@@ -56,7 +56,7 @@ fn simple_update() {
         }
     );
 
-    graph.apply_additions(&additions);
+    graph.apply_additions(additions);
     assert_eq!(graph.iter_all_txouts().count(), 3);
     assert_eq!(graph.iter_full_transactions().count(), 0);
     assert_eq!(graph.iter_partial_transactions().count(), 2);

--- a/bdk_core/tests/test_tx_graph.rs
+++ b/bdk_core/tests/test_tx_graph.rs
@@ -1,10 +1,12 @@
 #[macro_use]
 mod common;
+use bdk_core::collections::*;
 use bdk_core::tx_graph::{Additions, TxGraph};
-use bitcoin::{OutPoint, Script, TxOut};
+use bitcoin::{hashes::Hash, OutPoint, PackedLockTime, Script, Transaction, TxIn, TxOut, Txid};
+use core::iter;
 
 #[test]
-fn simple_update() {
+fn insert_txouts() {
     let original_ops = [
         (
             OutPoint::new(h!("tx1"), 1),
@@ -60,4 +62,80 @@ fn simple_update() {
     assert_eq!(graph.iter_all_txouts().count(), 3);
     assert_eq!(graph.iter_full_transactions().count(), 0);
     assert_eq!(graph.iter_partial_transactions().count(), 2);
+}
+
+#[test]
+fn insert_tx_graph_doesnt_count_coinbase_as_spent() {
+    let tx = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(0),
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            ..Default::default()
+        }],
+        output: vec![],
+    };
+
+    let mut graph = TxGraph::default();
+    graph.insert_tx(tx);
+    assert!(graph.outspends(OutPoint::null()).is_empty());
+    assert!(graph.tx_outspends(Txid::all_zeros()).next().is_none());
+}
+
+#[test]
+fn insert_tx_graph_keeps_track_of_spend() {
+    let tx1 = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(0),
+        input: vec![],
+        output: vec![TxOut::default()],
+    };
+
+    let op = OutPoint {
+        txid: tx1.txid(),
+        vout: 0,
+    };
+
+    let tx2 = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(0),
+        input: vec![TxIn {
+            previous_output: op,
+            ..Default::default()
+        }],
+        output: vec![],
+    };
+
+    let mut graph1 = TxGraph::default();
+    let mut graph2 = TxGraph::default();
+
+    // insert in different order
+    graph1.insert_tx(tx1.clone());
+    graph1.insert_tx(tx2.clone());
+
+    graph2.insert_tx(tx2.clone());
+    graph2.insert_tx(tx1.clone());
+
+    assert_eq!(
+        &*graph1.outspends(op),
+        &iter::once(tx2.txid()).collect::<HashSet<_>>()
+    );
+    assert_eq!(graph2.outspends(op), graph1.outspends(op));
+}
+
+#[test]
+fn insert_tx_can_retrieve_full_tx_from_graph() {
+    let tx = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(0),
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            ..Default::default()
+        }],
+        output: vec![TxOut::default()],
+    };
+
+    let mut graph = TxGraph::default();
+    graph.insert_tx(tx.clone());
+    assert_eq!(graph.tx(tx.txid()), Some(&tx));
 }

--- a/bdk_keychain/src/keychain_tracker.rs
+++ b/bdk_keychain/src/keychain_tracker.rs
@@ -49,7 +49,7 @@ where
         self.txout_index
             .store_all_up_to(&changeset.derivation_indices);
         self.txout_index.scan(&changeset);
-        self.chain_graph.apply_changeset(&changeset.chain_graph);
+        self.chain_graph.apply_changeset(changeset.chain_graph);
     }
 
     pub fn txouts(&self) -> impl Iterator<Item = (&(K, u32), FullTxOut<I>)> + '_ {


### PR DESCRIPTION
- We were recording spends of coinbase tx. Fixed and added tests.
- removed `is_unspent` to `spent_by` which returns the actual spender and index in chain.