### PR TITLE
Enforce invariants for `ChainGraph` structure

### DIFF
--- a/bdk_core/src/keychain.rs
+++ b/bdk_core/src/keychain.rs
@@ -68,7 +68,7 @@ impl<K, I> From<chain_graph::ChangeSet<I>> for KeychainChangeSet<K, I> {
 
 impl<K, I> AsRef<TxGraph> for KeychainScan<K, I> {
     fn as_ref(&self) -> &TxGraph {
-        &self.update.graph
+        self.update.graph()
     }
 }
 

--- a/bdk_core/tests/test_chain_graph.rs
+++ b/bdk_core/tests/test_chain_graph.rs
@@ -43,14 +43,16 @@ fn test_spent_by() {
     };
 
     let mut cg1 = ChainGraph::default();
-    cg1.insert_tx(tx1, TxHeight::Unconfirmed).unwrap();
+    cg1.insert_tx(tx1, Some(TxHeight::Unconfirmed)).unwrap();
     let mut cg2 = cg1.clone();
-    cg1.insert_tx(tx2.clone(), TxHeight::Unconfirmed).unwrap();
-    cg2.insert_tx(tx3.clone(), TxHeight::Unconfirmed).unwrap();
+    cg1.insert_tx(tx2.clone(), Some(TxHeight::Unconfirmed))
+        .unwrap();
+    cg2.insert_tx(tx3.clone(), Some(TxHeight::Unconfirmed))
+        .unwrap();
     // put the these txs in the graph but not in chain. `spent_by` should return the one that was
     // actually in the respective chain.
-    cg1.graph.insert_tx(tx3.clone());
-    cg2.graph.insert_tx(tx2.clone());
+    cg1.insert_tx(tx3.clone(), None).expect("should insert");
+    cg2.insert_tx(tx2.clone(), None).expect("should insert");
 
     assert_eq!(cg1.spent_by(op), Some((&TxHeight::Unconfirmed, tx2.txid())));
     assert_eq!(cg2.spent_by(op), Some((&TxHeight::Unconfirmed, tx3.txid())));
@@ -101,15 +103,15 @@ fn update_evicts_conflicting_tx() {
     let cg1 = {
         let mut cg = ChainGraph::default();
         cg.insert_checkpoint(cp_a).expect("should insert cp");
-        cg.insert_tx(tx_a.clone(), TxHeight::Confirmed(0))
+        cg.insert_tx(tx_a.clone(), Some(TxHeight::Confirmed(0)))
             .expect("should insert tx");
-        cg.insert_tx(tx_b.clone(), TxHeight::Unconfirmed)
+        cg.insert_tx(tx_b.clone(), Some(TxHeight::Unconfirmed))
             .expect("should insert tx");
         cg
     };
     let cg2 = {
         let mut cg = ChainGraph::default();
-        cg.insert_tx(tx_b2.clone(), TxHeight::Unconfirmed)
+        cg.insert_tx(tx_b2.clone(), Some(TxHeight::Unconfirmed))
             .expect("should insert tx");
         cg
     };
@@ -136,15 +138,15 @@ fn update_evicts_conflicting_tx() {
         let mut cg = ChainGraph::default();
         cg.insert_checkpoint(cp_a).expect("should insert cp");
         cg.insert_checkpoint(cp_b).expect("should insert cp");
-        cg.insert_tx(tx_a.clone(), TxHeight::Confirmed(0))
+        cg.insert_tx(tx_a.clone(), Some(TxHeight::Confirmed(0)))
             .expect("should insert tx");
-        cg.insert_tx(tx_b.clone(), TxHeight::Confirmed(1))
+        cg.insert_tx(tx_b.clone(), Some(TxHeight::Confirmed(1)))
             .expect("should insert tx");
         cg
     };
     let cg2 = {
         let mut cg = ChainGraph::default();
-        cg.insert_tx(tx_b2.clone(), TxHeight::Unconfirmed)
+        cg.insert_tx(tx_b2.clone(), Some(TxHeight::Unconfirmed))
             .expect("should insert tx");
         cg
     };

--- a/bdk_esplora_example/src/esplora.rs
+++ b/bdk_esplora_example/src/esplora.rs
@@ -163,7 +163,7 @@ impl Client {
                             },
                             false => ConfirmationTime::Unconfirmed,
                         };
-                        if let Err(err) = update.insert_tx(tx.to_tx(), confirmation_time) {
+                        if let Err(err) = update.insert_tx(tx.to_tx(), Some(confirmation_time)) {
                             match err {
                                 InsertTxErr::TxTooHigh => {
                                     /* Don't care about new transactions confirmed while syncing */

--- a/bdk_keychain/src/keychain_tracker.rs
+++ b/bdk_keychain/src/keychain_tracker.rs
@@ -85,15 +85,11 @@ where
     }
 
     pub fn graph(&self) -> &TxGraph {
-        &self.chain_graph().graph
+        &self.chain_graph().graph()
     }
 
     pub fn chain(&self) -> &SparseChain<I> {
-        &self.chain_graph().chain
-    }
-
-    pub fn chain_mut(&mut self) -> &mut SparseChain<I> {
-        &mut self.chain_graph.chain
+        &self.chain_graph().chain()
     }
 }
 


### PR DESCRIPTION
The `ChainGraph` structure now ensures there are no "floating txids". All txids mentioned in the internal chain must exist in the internal graph.