### PR TITLE
Make chain_graph::apply_changeset safe

### DIFF
--- a/bdk_core/src/chain_graph.rs
+++ b/bdk_core/src/chain_graph.rs
@@ -1,4 +1,5 @@
 use crate::{
+    collections::HashSet,
     sparse_chain::{self, ChainIndex, SparseChain},
     tx_graph::{self, TxGraph},
     BlockId, ForEachTxout, FullTxOut, TxHeight,
@@ -142,9 +143,61 @@ impl<I: ChainIndex> ChainGraph<I> {
     }
 
     /// Applies a [`ChangeSet`] to the chain graph
-    pub fn apply_changeset(&mut self, changeset: ChangeSet<I>) {
-        self.chain.apply_changeset(changeset.chain);
-        self.graph.apply_additions(changeset.graph);
+    pub fn apply_changeset(
+        &mut self,
+        changeset: ChangeSet<I>,
+    ) -> Result<(), (ChangeSet<I>, HashSet<Txid>)> {
+        let mut missing: HashSet<Txid> = self.chain.changeset_additions(&changeset.chain).collect();
+
+        for tx in &changeset.graph.tx {
+            missing.remove(&tx.txid());
+        }
+
+        missing.retain(|txid| !self.graph.contains_txid(*txid));
+
+        if missing.is_empty() {
+            self.chain.apply_changeset(changeset.chain);
+            self.graph.apply_additions(changeset.graph);
+            Ok(())
+        } else {
+            Err((changeset, missing))
+        }
+    }
+
+    /// Convets a [`sparse_chain::ChangeSet`] to a valid [`chain_graph::ChangeSet`] by providing
+    /// full transactions for each addition.
+    ///
+    pub fn inflate_changeset(
+        &self,
+        changeset: sparse_chain::ChangeSet<I>,
+        full_txs: impl IntoIterator<Item = Transaction>,
+    ) -> Result<ChangeSet<I>, (sparse_chain::ChangeSet<I>, HashSet<Txid>)> {
+        let mut missing = self
+            .chain
+            .changeset_additions(&changeset)
+            .collect::<HashSet<_>>();
+        missing.retain(|txid| !self.graph.contains_txid(*txid));
+        // need to wrap in a refcell because it's closed over twice below
+        let missing = core::cell::RefCell::new(missing);
+        let full_txs = full_txs
+            .into_iter()
+            .take_while(|_| !missing.borrow().is_empty())
+            .filter(|tx| missing.borrow_mut().remove(&tx.txid()))
+            .collect();
+
+        let missing = missing.into_inner();
+
+        if missing.is_empty() {
+            Ok(ChangeSet {
+                chain: changeset,
+                graph: tx_graph::Additions {
+                    tx: full_txs,
+                    ..Default::default()
+                },
+            })
+        } else {
+            Err((changeset, missing))
+        }
     }
 
     /// Applies the `update` chain graph. Note this is shorthand for calling [`determine_changeset`]
@@ -154,7 +207,8 @@ impl<I: ChainIndex> ChainGraph<I> {
     /// [`determine_changeset`]: Self::determine_changeset
     pub fn apply_update(&mut self, update: Self) -> Result<(), UpdateFailure<I>> {
         let changeset = self.determine_changeset(&update)?;
-        self.apply_changeset(changeset);
+        self.apply_changeset(changeset)
+            .expect("we correctly constructed this");
         Ok(())
     }
 

--- a/bdk_core/tests/common/mod.rs
+++ b/bdk_core/tests/common/mod.rs
@@ -34,7 +34,7 @@ macro_rules! changeset {
         use bdk_core::collections::BTreeMap;
 
         #[allow(unused_mut)]
-        ChangeSet::<$ind> {
+        bdk_core::sparse_chain::ChangeSet::<$ind> {
             checkpoints: {
                 let mut changes = BTreeMap::default();
                 $(changes.insert($height, $cp_to);)*

--- a/bdk_core/tests/test_chain_graph.rs
+++ b/bdk_core/tests/test_chain_graph.rs
@@ -3,11 +3,14 @@ mod common;
 
 use bdk_core::{
     chain_graph::{ChainGraph, ChangeSet, UpdateFailure},
+    collections::HashSet,
     sparse_chain,
-    tx_graph::Additions,
+    tx_graph::{self, Additions},
     BlockId, TxHeight,
 };
-use bitcoin::{OutPoint, PackedLockTime, Script, Sequence, Transaction, TxIn, TxOut, Witness};
+use bitcoin::{
+    OutPoint, PackedLockTime, Script, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
+};
 
 #[test]
 fn test_spent_by() {
@@ -103,103 +106,236 @@ fn update_evicts_conflicting_tx() {
         }],
         output: vec![TxOut::default(), TxOut::default()],
     };
+    {
+        let mut cg1 = {
+            let mut cg = ChainGraph::default();
+            cg.insert_checkpoint(cp_a).expect("should insert cp");
+            cg.insert_tx(tx_a.clone(), Some(TxHeight::Confirmed(0)))
+                .expect("should insert tx");
+            cg.insert_tx(tx_b.clone(), Some(TxHeight::Unconfirmed))
+                .expect("should insert tx");
+            cg
+        };
+        let cg2 = {
+            let mut cg = ChainGraph::default();
+            cg.insert_tx(tx_b2.clone(), Some(TxHeight::Unconfirmed))
+                .expect("should insert tx");
+            cg
+        };
 
-    let cg1 = {
-        let mut cg = ChainGraph::default();
-        cg.insert_checkpoint(cp_a).expect("should insert cp");
-        cg.insert_tx(tx_a.clone(), Some(TxHeight::Confirmed(0)))
-            .expect("should insert tx");
-        cg.insert_tx(tx_b.clone(), Some(TxHeight::Unconfirmed))
-            .expect("should insert tx");
-        cg
-    };
-    let cg2 = {
-        let mut cg = ChainGraph::default();
-        cg.insert_tx(tx_b2.clone(), Some(TxHeight::Unconfirmed))
-            .expect("should insert tx");
-        cg
-    };
-    assert_eq!(
-        cg1.determine_changeset(&cg2),
-        Ok(ChangeSet::<TxHeight> {
+        let changeset = ChangeSet::<TxHeight> {
             chain: sparse_chain::ChangeSet {
                 checkpoints: Default::default(),
                 txids: [
                     (tx_b.txid(), None),
-                    (tx_b2.txid(), Some(TxHeight::Unconfirmed))
+                    (tx_b2.txid(), Some(TxHeight::Unconfirmed)),
                 ]
-                .into()
-            },
-            graph: Additions {
-                tx: [tx_b2.clone()].into(),
-                txout: [].into()
-            },
-        }),
-        "tx should be evicted from mempool"
-    );
-
-    let cg1 = {
-        let mut cg = ChainGraph::default();
-        cg.insert_checkpoint(cp_a).expect("should insert cp");
-        cg.insert_checkpoint(cp_b).expect("should insert cp");
-        cg.insert_tx(tx_a.clone(), Some(TxHeight::Confirmed(0)))
-            .expect("should insert tx");
-        cg.insert_tx(tx_b.clone(), Some(TxHeight::Confirmed(1)))
-            .expect("should insert tx");
-        cg
-    };
-    let cg2 = {
-        let mut cg = ChainGraph::default();
-        cg.insert_tx(tx_b2.clone(), Some(TxHeight::Unconfirmed))
-            .expect("should insert tx");
-        cg
-    };
-    assert_eq!(
-        cg1.determine_changeset(&cg2),
-        Err(UpdateFailure::Conflict {
-            already_confirmed_tx: (TxHeight::Confirmed(1), tx_b.txid()),
-            update_tx: (TxHeight::Unconfirmed, tx_b2.txid()),
-        }),
-        "fail if tx is evicted from valid block"
-    );
-
-    // Given 2 blocks `{A, B}`, and an update that invalidates block B with
-    // `{A, B'}`, we expect txs that exist in `B` that conflicts with txs
-    // introduced in the update to be successfully evicted.
-    let cg1 = {
-        let mut cg = ChainGraph::default();
-        cg.insert_checkpoint(cp_a).expect("should insert cp");
-        cg.insert_checkpoint(cp_b).expect("should insert cp");
-        cg.insert_tx(tx_a.clone(), Some(TxHeight::Confirmed(0)))
-            .expect("should insert tx");
-        cg.insert_tx(tx_b.clone(), Some(TxHeight::Confirmed(1)))
-            .expect("should insert tx");
-        cg
-    };
-    let cg2 = {
-        let mut cg = ChainGraph::default();
-        cg.insert_checkpoint(cp_a).expect("should insert cp");
-        cg.insert_checkpoint(cp_b2).expect("should insert cp");
-        cg.insert_tx(tx_b2.clone(), Some(TxHeight::Unconfirmed))
-            .expect("should insert tx");
-        cg
-    };
-    assert_eq!(
-        cg1.determine_changeset(&cg2),
-        Ok(ChangeSet::<TxHeight> {
-            chain: sparse_chain::ChangeSet {
-                checkpoints: [(1, Some(h!("B'")))].into(),
-                txids: [
-                    (tx_b.txid(), None),
-                    (tx_b2.txid(), Some(TxHeight::Unconfirmed))
-                ]
-                .into()
+                .into(),
             },
             graph: Additions {
                 tx: [tx_b2.clone()].into(),
                 txout: [].into(),
             },
-        }),
-        "tx should be evicted from B",
+        };
+        assert_eq!(
+            cg1.determine_changeset(&cg2),
+            Ok(changeset.clone()),
+            "tx should be evicted from mempool"
+        );
+
+        cg1.apply_changeset(changeset).expect("should apply");
+    }
+
+    {
+        let cg1 = {
+            let mut cg = ChainGraph::default();
+            cg.insert_checkpoint(cp_a).expect("should insert cp");
+            cg.insert_checkpoint(cp_b).expect("should insert cp");
+            cg.insert_tx(tx_a.clone(), Some(TxHeight::Confirmed(0)))
+                .expect("should insert tx");
+            cg.insert_tx(tx_b.clone(), Some(TxHeight::Confirmed(1)))
+                .expect("should insert tx");
+            cg
+        };
+        let cg2 = {
+            let mut cg = ChainGraph::default();
+            cg.insert_tx(tx_b2.clone(), Some(TxHeight::Unconfirmed))
+                .expect("should insert tx");
+            cg
+        };
+        assert_eq!(
+            cg1.determine_changeset(&cg2),
+            Err(UpdateFailure::Conflict {
+                already_confirmed_tx: (TxHeight::Confirmed(1), tx_b.txid()),
+                update_tx: (TxHeight::Unconfirmed, tx_b2.txid()),
+            }),
+            "fail if tx is evicted from valid block"
+        );
+    }
+
+    {
+        // Given 2 blocks `{A, B}`, and an update that invalidates block B with
+        // `{A, B'}`, we expect txs that exist in `B` that conflicts with txs
+        // introduced in the update to be successfully evicted.
+        let mut cg1 = {
+            let mut cg = ChainGraph::default();
+            cg.insert_checkpoint(cp_a).expect("should insert cp");
+            cg.insert_checkpoint(cp_b).expect("should insert cp");
+            cg.insert_tx(tx_a.clone(), Some(TxHeight::Confirmed(0)))
+                .expect("should insert tx");
+            cg.insert_tx(tx_b.clone(), Some(TxHeight::Confirmed(1)))
+                .expect("should insert tx");
+            cg
+        };
+        let cg2 = {
+            let mut cg = ChainGraph::default();
+            cg.insert_checkpoint(cp_a).expect("should insert cp");
+            cg.insert_checkpoint(cp_b2).expect("should insert cp");
+            cg.insert_tx(tx_b2.clone(), Some(TxHeight::Unconfirmed))
+                .expect("should insert tx");
+            cg
+        };
+
+        let changeset = ChangeSet::<TxHeight> {
+            chain: sparse_chain::ChangeSet {
+                checkpoints: [(1, Some(h!("B'")))].into(),
+                txids: [
+                    (tx_b.txid(), None),
+                    (tx_b2.txid(), Some(TxHeight::Unconfirmed)),
+                ]
+                .into(),
+            },
+            graph: Additions {
+                tx: [tx_b2.clone()].into(),
+                txout: [].into(),
+            },
+        };
+        assert_eq!(
+            cg1.determine_changeset(&cg2),
+            Ok(changeset.clone()),
+            "tx should be evicted from B",
+        );
+
+        cg1.apply_changeset(changeset).expect("should apply");
+    }
+}
+
+#[test]
+fn update_missing_full_tx_errors() {
+    let mut cg = ChainGraph::default();
+    let chain_changeset = changeset! {
+        checkpoints: [
+            (0, Some(h!("A")))
+        ],
+        txids: [
+            (h!("a1"), Some(TxHeight::Confirmed(0))),
+            (h!("a2"), Some(TxHeight::Unconfirmed))
+        ]
+    };
+    let changeset = ChangeSet {
+        chain: chain_changeset,
+        graph: tx_graph::Additions::default(),
+    };
+    let mut expected = HashSet::<Txid>::new();
+    expected.insert(h!("a1"));
+    expected.insert(h!("a2"));
+    assert_eq!(
+        cg.apply_changeset(changeset.clone()),
+        Err((changeset, expected))
     );
+}
+
+#[test]
+fn update_not_including_tx_already_in_graph_is_ok() {
+    let mut cg = ChainGraph::default();
+    let tx_a = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(0),
+        input: vec![],
+        output: vec![TxOut::default()],
+    };
+    let chain_changeset = changeset! {
+        checkpoints: [ (0, Some(h!("A"))) ],
+        txids: [
+            (tx_a.txid(), Some(TxHeight::Confirmed(0)))
+        ]
+    };
+
+    let mut graph_additions = tx_graph::Additions::default();
+    graph_additions.tx.insert(tx_a.clone());
+    let changeset = ChangeSet {
+        chain: chain_changeset,
+        graph: graph_additions,
+    };
+
+    assert_eq!(cg.apply_changeset(changeset), Ok(()));
+
+    // reorg the tx to a different height and provide changeset without the full tx.
+    let chain_changeset = changeset! {
+        checkpoints: [(0, Some(h!("A'")))],
+        txids: [
+            (tx_a.txid(), Some(TxHeight::Unconfirmed))
+        ]
+    };
+
+    let changeset = ChangeSet {
+        chain: chain_changeset,
+        graph: tx_graph::Additions::default(),
+    };
+
+    assert_eq!(cg.apply_changeset(changeset), Ok(()));
+}
+
+#[test]
+fn chain_graph_inflate_changeset() {
+    let mut cg = ChainGraph::default();
+    let tx_a = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(0),
+        input: vec![],
+        output: vec![TxOut::default()],
+    };
+    let tx_b = Transaction {
+        version: 0x02,
+        lock_time: PackedLockTime(0),
+        input: vec![],
+        output: vec![TxOut::default()],
+    };
+
+    let chain_changeset = changeset! {
+        checkpoints: [ (0, Some(h!("A"))) ],
+        txids: [
+            (tx_a.txid(), Some(TxHeight::Confirmed(0))),
+            (tx_b.txid(), Some(TxHeight::Confirmed(0)))
+        ]
+    };
+
+    let mut expected_missing = HashSet::new();
+    expected_missing.insert(tx_a.txid());
+    expected_missing.insert(tx_b.txid());
+
+    assert_eq!(
+        cg.inflate_changeset(chain_changeset.clone(), vec![]),
+        Err((chain_changeset.clone(), expected_missing.clone()))
+    );
+
+    expected_missing.remove(&tx_b.txid());
+    assert_eq!(
+        cg.inflate_changeset(chain_changeset.clone(), vec![tx_b.clone()]),
+        Err((chain_changeset.clone(), expected_missing))
+    );
+
+    let mut additions = tx_graph::Additions::default();
+    additions.tx.insert(tx_a.clone());
+    additions.tx.insert(tx_b.clone());
+    let changeset = cg.inflate_changeset(chain_changeset.clone(), vec![tx_a, tx_b]);
+    assert_eq!(
+        changeset,
+        Ok(ChangeSet {
+            chain: chain_changeset,
+            graph: additions
+        })
+    );
+
+    assert_eq!(cg.apply_changeset(changeset.unwrap()), Ok(()))
 }


### PR DESCRIPTION
- Make ChainGraph::apply_changeset safe (doesn't add txid to chain without adding full tx to graph).
- Add inflate_changeset to safely turn a sparse_chain changeset into a chain_graph changeset.

This is to make #77 a bit cleaner. See PR to #77 here: https://github.com/rajarshimaitra/bdk_core_staging/pull/1 which does the best job we can do without these changes. 