### PR TITLE
Add ChainGraph::get_tx_in_chain

### DIFF
--- a/bdk_core/src/chain_graph.rs
+++ b/bdk_core/src/chain_graph.rs
@@ -69,6 +69,17 @@ impl<I: ChainIndex> ChainGraph<I> {
         })
     }
 
+    /// Get a transaction that is currently in the underlying [`SparseChain`]. This doesn't
+    /// necessarily mean that it is *confirmed* in the blockchain, it might just be in the
+    /// unconfirmed transaction list within the `SparseChain`.
+    ///
+    /// [`SparseChain`]: crate::sparse_chain::SparseChain
+    pub fn get_tx_in_chain(&self, txid: Txid) -> Option<(&I, &Transaction)> {
+        let position = self.chain.tx_index(txid)?;
+        let full_tx = self.graph.tx(txid).expect("must exist");
+        Some((position, full_tx))
+    }
+
     pub fn insert_output(&mut self, outpoint: OutPoint, txout: TxOut) -> bool {
         self.graph.insert_txout(outpoint, txout)
     }

--- a/bdk_core/src/lib.rs
+++ b/bdk_core/src/lib.rs
@@ -19,9 +19,6 @@ extern crate alloc;
 #[cfg(feature = "serde")]
 extern crate serde_crate as serde;
 
-#[cfg(feature = "bincode")]
-extern crate bincode_crate as bincode;
-
 #[cfg(feature = "std")]
 #[macro_use]
 extern crate std;

--- a/bdk_core/tests/test_chain_graph.rs
+++ b/bdk_core/tests/test_chain_graph.rs
@@ -339,3 +339,24 @@ fn chain_graph_inflate_changeset() {
 
     assert_eq!(cg.apply_changeset(changeset.unwrap()), Ok(()))
 }
+
+#[test]
+fn test_get_tx_in_chain() {
+    let mut cg = ChainGraph::default();
+    let tx = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(0),
+        input: vec![],
+        output: vec![TxOut::default()],
+    };
+
+    cg.insert_tx(tx.clone(), None).unwrap();
+    assert_eq!(cg.get_tx_in_chain(tx.txid()), None);
+
+    cg.insert_tx(tx.clone(), Some(TxHeight::Unconfirmed))
+        .unwrap();
+    assert_eq!(
+        cg.get_tx_in_chain(tx.txid()),
+        Some((&TxHeight::Unconfirmed, &tx))
+    );
+}


### PR DESCRIPTION
A useful utility for getting a full transaction in the chain.

Also deletes bincode feature flag not used that I just noticed.