### PR TITLE
Fix KeychainTracker::insert_tx

### DIFF
--- a/bdk_keychain/src/keychain_txout_index.rs
+++ b/bdk_keychain/src/keychain_txout_index.rs
@@ -93,10 +93,15 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
         &self.inner
     }
 
+    /// Get the internal map of keychains to their descriptors.
     pub fn keychains(&self) -> &BTreeMap<K, Descriptor<DescriptorPublicKey>> {
         &self.keychains
     }
 
+    /// Add a keychain to the tracker's `txout_index` with a descriptor to derive addresses for it.
+    ///
+    /// Adding a keychain means you will be able to derive new script pubkeys under that keychain
+    /// and the txout index will discover transaction outputs with those script pubkeys.
     pub fn add_keychain(&mut self, keychain: K, descriptor: Descriptor<DescriptorPublicKey>) {
         // TODO: panic if already different descriptor at that keychain
         self.keychains.insert(keychain, descriptor);

--- a/bdk_keychain/tests/test_keychain_tracker.rs
+++ b/bdk_keychain/tests/test_keychain_tracker.rs
@@ -1,0 +1,48 @@
+use bdk_core::ConfirmationTime;
+use bdk_keychain::KeychainTracker;
+use miniscript::{
+    bitcoin::{secp256k1::Secp256k1, OutPoint, PackedLockTime, Transaction, TxOut},
+    Descriptor,
+};
+
+#[test]
+fn test_insert_tx() {
+    let mut tracker = KeychainTracker::default();
+    let secp = Secp256k1::new();
+    let (descriptor, _) = Descriptor::parse_descriptor(&secp, "tr([73c5da0a/86'/0'/0']xprv9xgqHN7yz9MwCkxsBPN5qetuNdQSUttZNKw1dcYTV4mkaAFiBVGQziHs3NRSWMkCzvgjEe3n9xV8oYywvM8at9yRqyaZVz6TYYhX98VjsUk/0/*)").unwrap();
+    tracker.add_keychain((), descriptor.clone());
+    let txout = TxOut {
+        value: 100_000,
+        script_pubkey: descriptor.at_derivation_index(5).script_pubkey(),
+    };
+
+    let tx = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(0),
+        input: vec![],
+        output: vec![txout],
+    };
+
+    assert!(tracker.txout_index.store_up_to(&(), 5));
+    tracker
+        .insert_tx(tx.clone(), Some(ConfirmationTime::Unconfirmed))
+        .unwrap();
+    assert_eq!(
+        tracker
+            .chain_graph()
+            .transactions_in_chain()
+            .collect::<Vec<_>>(),
+        vec![(&ConfirmationTime::Unconfirmed, &tx)]
+    );
+
+    assert_eq!(
+        tracker.txout_index.keychain_txouts(&()).collect::<Vec<_>>(),
+        vec![(
+            5,
+            OutPoint {
+                txid: tx.txid(),
+                vout: 0
+            }
+        )]
+    );
+}


### PR DESCRIPTION
I forgot to scan the output after inserting it.
I also added some natural `add_keychain` and `keychains` methods on it.