### PR TITLE
Evan's version of the electrum example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "bdk_core",
     "bdk_cli_lib",
     "bdk_esplora_example",
+    "bdk_electrum_example",
     "bdk_keychain",
     "bdk_file_store"
 ]

--- a/bdk_core/src/chain_graph.rs
+++ b/bdk_core/src/chain_graph.rs
@@ -265,6 +265,20 @@ impl<I> ChangeSet<I> {
     }
 }
 
+impl<I: ChainIndex> ChangeSet<I> {
+    pub fn merge(self, new_set: Self) -> Self {
+        let Self { chain, graph } = self;
+        let Self {
+            chain: new_chain,
+            graph: new_graph,
+        } = new_set;
+        Self {
+            chain: chain.merge(new_chain),
+            graph: graph.merge(new_graph),
+        }
+    }
+}
+
 impl<I> Default for ChangeSet<I> {
     fn default() -> Self {
         Self {
@@ -313,3 +327,12 @@ impl<I: core::fmt::Debug> core::fmt::Display for UpdateFailure<I> {
 
 #[cfg(feature = "std")]
 impl<I: core::fmt::Debug> std::error::Error for UpdateFailure<I> {}
+
+impl<I> From<TxGraph> for ChainGraph<I> {
+    fn from(graph: TxGraph) -> Self {
+        Self {
+            graph,
+            ..Default::default()
+        }
+    }
+}

--- a/bdk_core/src/spk_txout_index.rs
+++ b/bdk_core/src/spk_txout_index.rs
@@ -191,6 +191,16 @@ impl<I: Clone + Ord> SpkTxOutIndex<I> {
         self.unused.get(index).is_none()
     }
 
+    /// Removes an unused index.
+    pub fn remove_unused(&mut self, index: &I) -> bool {
+        let is_removed = self.unused.remove(index);
+        if is_removed {
+            let spk = self.script_pubkeys.remove(index).expect("should exist");
+            self.spk_indexes.remove(&spk);
+        }
+        is_removed
+    }
+
     /// Returns the index associated with the script pubkey.
     pub fn index_of_spk(&self, script: &Script) -> Option<I> {
         self.spk_indexes.get(script).cloned()

--- a/bdk_core/src/tx_graph.rs
+++ b/bdk_core/src/tx_graph.rs
@@ -8,6 +8,16 @@ pub struct TxGraph {
     spends: BTreeMap<OutPoint, HashSet<Txid>>,
 }
 
+impl<I: IntoIterator<Item = Transaction>> From<I> for TxGraph {
+    fn from(txs: I) -> Self {
+        let mut graph = Self::default();
+        for tx in txs {
+            graph.insert_tx(tx);
+        }
+        graph
+    }
+}
+
 /// Node of a [`TxGraph`]
 #[derive(Clone, Debug, PartialEq)]
 enum TxNode {

--- a/bdk_core/src/tx_graph.rs
+++ b/bdk_core/src/tx_graph.rs
@@ -285,6 +285,12 @@ impl Additions {
             })
             .chain(self.txout.iter().map(|(op, txout)| (*op, txout)))
     }
+
+    pub fn merge(mut self, mut new_additions: Self) -> Self {
+        self.tx.append(&mut new_additions.tx);
+        self.txout.append(&mut new_additions.txout);
+        self
+    }
 }
 
 impl<T: AsRef<TxGraph>> ForEachTxout for T {

--- a/bdk_electrum_example/Cargo.toml
+++ b/bdk_electrum_example/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "bdk_electrum_example"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+# BDK Core
+bdk_core = { path = "../bdk_core", features = ["serde"] }
+bdk_cli = { path = "../bdk_cli_lib"}
+bdk_keychain = { path = "../bdk_keychain" }
+
+# Electrum
+electrum-client = { version = "0.12" }
+
+# Auxiliary
+log = "0.4"
+env_logger = "0.7"

--- a/bdk_electrum_example/src/electrum.rs
+++ b/bdk_electrum_example/src/electrum.rs
@@ -1,0 +1,205 @@
+use std::{collections::BTreeMap, ops::Deref};
+
+use bdk_cli::Broadcast;
+use bdk_core::{
+    bitcoin::{BlockHash, Script, Txid},
+    sparse_chain::{InsertTxErr, SparseChain},
+    BlockId, TxHeight,
+};
+use electrum_client::{Client, Config, ElectrumApi};
+
+#[derive(Debug)]
+pub enum ElectrumError {
+    Client(electrum_client::Error),
+    Reorg(u32),
+}
+
+impl core::fmt::Display for ElectrumError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ElectrumError::Client(e) => write!(f, "{}", e),
+            ElectrumError::Reorg(height) => write!(f, "Reorg detected at height : {}", height),
+        }
+    }
+}
+
+impl std::error::Error for ElectrumError {}
+
+impl From<electrum_client::Error> for ElectrumError {
+    fn from(e: electrum_client::Error) -> Self {
+        Self::Client(e)
+    }
+}
+
+pub struct ElectrumClient {
+    client: Client,
+}
+
+impl ElectrumClient {
+    pub fn new(url: &str) -> Result<Self, ElectrumError> {
+        let client = Client::from_config(url, Config::default())?;
+        Ok(Self { client })
+    }
+}
+
+impl Deref for ElectrumClient {
+    type Target = Client;
+    fn deref(&self) -> &Self::Target {
+        &self.client
+    }
+}
+
+impl Broadcast for ElectrumClient {
+    type Error = ElectrumError;
+    fn broadcast(&self, tx: &bdk_core::bitcoin::Transaction) -> Result<(), Self::Error> {
+        let _ = self.client.transaction_broadcast(tx)?;
+        Ok(())
+    }
+}
+
+impl ElectrumClient {
+    /// Fetch latest block height.
+    pub fn get_tip(&self) -> Result<(u32, BlockHash), ElectrumError> {
+        // TODO: unsubscribe when added to the client, or is there a better call to use here?
+        Ok(self
+            .client
+            .block_headers_subscribe()
+            .map(|data| (data.height as u32, data.header.block_hash()))?)
+    }
+
+    /// Scan for a list of scripts, and create an initial [`ChainGraph`] candidate update.
+    /// This update will only contain [`Txid`]s in SparseChain, and no actual transaction data.
+    ///
+    /// User needs to fetch the required transaction data and update the [`ChainGraph`] before applying it.
+    pub fn spk_txid_scan(
+        &self,
+        spks: impl Iterator<Item = Script>,
+        local_chain: &BTreeMap<u32, BlockHash>,
+    ) -> Result<SparseChain, ElectrumError> {
+        let mut dummy_keychains = BTreeMap::new();
+        dummy_keychains.insert((), spks.enumerate().map(|(i, spk)| (i as u32, spk)));
+
+        Ok(self.wallet_txid_scan(dummy_keychains, None, local_chain)?.0)
+    }
+
+    /// Scan for a keychain tracker, and create an initial [`KeychainScan`] candidate update.
+    /// This update will only contain [`Txid`]s in SparseChain, and no actual transaction data.
+    ///
+    /// User needs to fetch the required transaction data and update the [`KeychainScan`] before applying it.
+    pub fn wallet_txid_scan<K: Ord + Clone>(
+        &self,
+        scripts: BTreeMap<K, impl Iterator<Item = (u32, Script)>>,
+        stop_gap: Option<usize>,
+        local_chain: &BTreeMap<u32, BlockHash>,
+    ) -> Result<(SparseChain, BTreeMap<K, u32>), ElectrumError> {
+        let mut sparse_chain = SparseChain::default();
+
+        // Check for reorgs.
+        // In case of reorg, new checkpoints until the last common checkpoint is added to the structure
+        for (&existing_height, &existing_hash) in local_chain.iter().rev() {
+            let current_hash = self
+                .client
+                .block_header(existing_height as usize)?
+                .block_hash();
+            sparse_chain
+                .insert_checkpoint(BlockId {
+                    height: existing_height,
+                    hash: current_hash,
+                })
+                .expect("This never errors because we are working with a fresh chain");
+
+            if current_hash == existing_hash {
+                break;
+            }
+        }
+
+        // Insert the new tip
+        let (tip_height, tip_hash) = self.get_tip()?;
+        if sparse_chain
+            .insert_checkpoint(BlockId {
+                height: tip_height,
+                hash: tip_hash,
+            })
+            .is_err()
+        {
+            // This means our existing chain tip has been reorged out.
+            return Err(ElectrumError::Reorg(tip_height));
+        }
+
+        let mut last_active_indexes = BTreeMap::new();
+
+        // Fetch Keychain's last_active_index and all related txids.
+        // Add them into the KeyChainScan
+        for (keychain, mut scripts) in scripts {
+            let mut last_active_index = 0_u32;
+            let mut unused_script_count = 0_usize;
+
+            while let Some((index, script)) = scripts.next() {
+                let history = self
+                    .script_get_history(&script)?
+                    .iter()
+                    .map(|history_result| {
+                        if history_result.height > 0 && (history_result.height as u32) <= tip_height
+                        {
+                            return (
+                                history_result.tx_hash,
+                                TxHeight::Confirmed(history_result.height as u32),
+                            );
+                        } else {
+                            return (history_result.tx_hash, TxHeight::Unconfirmed);
+                        };
+                    })
+                    .collect::<Vec<(Txid, TxHeight)>>();
+
+                if history.is_empty() {
+                    unused_script_count += 1;
+                    if unused_script_count >= stop_gap.unwrap_or(usize::MAX) {
+                        break;
+                    }
+                } else {
+                    unused_script_count = 0;
+                    last_active_index = index;
+
+                    for (txid, index) in history {
+                        if let Err(err) = sparse_chain.insert_tx(txid, index) {
+                            match err {
+                                InsertTxErr::TxTooHigh => {
+                                    /* We should not encounter this error as we ensured TxHeight <= tip_height */
+                                    unreachable!();
+                                }
+                                InsertTxErr::TxMoved => {
+                                    /* This means there is a reorg, we will handle this situation below */
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            last_active_indexes.insert(keychain, last_active_index);
+        }
+
+        // To detect reorgs during syncing we re-apply last known
+        // 20 blocks again into sparsechain
+        // TODO: Handle reorg case here, so user don't need to handle it manually.
+        let (tip_height, _) = self.get_tip()?;
+        let reorged_headers = self
+            .block_headers((tip_height - 20) as usize, 21)?
+            .headers
+            .into_iter()
+            .map(|header| header.block_hash())
+            .zip((tip_height - 20)..=tip_height);
+
+        // Insert the new checkpoints
+        for (hash, height) in reorged_headers {
+            if sparse_chain
+                .insert_checkpoint(BlockId { height, hash })
+                .is_err()
+            {
+                return Err(ElectrumError::Reorg(height));
+            };
+        }
+
+        Ok((sparse_chain, last_active_indexes))
+    }
+}

--- a/bdk_electrum_example/src/main.rs
+++ b/bdk_electrum_example/src/main.rs
@@ -1,0 +1,158 @@
+mod electrum;
+use bdk_core::bitcoin::Network;
+use bdk_keychain::KeychainChangeSet;
+use electrum::ElectrumClient;
+use std::fmt::Debug;
+
+use bdk_cli::{
+    anyhow::{self, Context},
+    clap::{self, Subcommand},
+};
+
+use electrum_client::ElectrumApi;
+
+#[derive(clap::Args, Debug, Clone)]
+struct ElectrumArgs {
+    #[clap(env = "ELECTRUM_URL", long)]
+    url: Option<String>,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+enum ElectrumCommands {
+    /// Scans the addresses in the wallet using esplora API.
+    Scan {
+        /// When a gap this large has been found for a keychain it will stop.
+        #[clap(long, default_value = "5")]
+        stop_gap: usize,
+    },
+    /// Scans particular addresses using esplora API
+    Sync {
+        /// Scan all the unused addresses
+        #[clap(long)]
+        unused: bool,
+        /// Scan the script addresses that have unspent outputs
+        #[clap(long)]
+        unspent: bool,
+        /// Scan every address that you have derived
+        #[clap(long)]
+        all: bool,
+    },
+}
+
+fn main() -> anyhow::Result<()> {
+    let (args, keymap, mut tracker, mut db) = bdk_cli::init::<ElectrumArgs, ElectrumCommands, _>()?;
+
+    let electrum_url = match &args.chain_args.url {
+        Some(url) => url.as_str(),
+        None => match args.network {
+            Network::Bitcoin => "ssl://electrum.blockstream.info:50002",
+            Network::Testnet => "ssl://electrum.blockstream.info:60002",
+            Network::Regtest => "ssl://localhost:60401",
+            // TODO: Find a electrum signet endpoint
+            Network::Signet => return Err(anyhow::anyhow!("Signet nor supported for Electrum")),
+        },
+    };
+
+    let client = ElectrumClient::new(electrum_url)?;
+
+    let electrum_cmd = match args.command {
+        bdk_cli::Commands::ChainSpecific(electrum_cmd) => electrum_cmd,
+        general_command => {
+            return bdk_cli::handle_commands(
+                general_command,
+                client,
+                &mut tracker,
+                &mut db,
+                args.network,
+                &keymap,
+            )
+        }
+    };
+
+    let mut changeset = KeychainChangeSet::default();
+
+    let update_chain = match electrum_cmd {
+        ElectrumCommands::Scan { stop_gap } => {
+            let scripts = tracker.txout_index.iter_all_script_pubkeys_by_keychain();
+
+            // Wallet scan returns a sparse chain that contains new All the BlockIds and Txids
+            // relevant to the wallet, along with keychain index update if required.
+            let (new_sparsechain, keychain_index_update) =
+                client.wallet_txid_scan(scripts, Some(stop_gap), tracker.chain().checkpoints())?;
+
+            tracker.txout_index.store_all_up_to(&keychain_index_update);
+            changeset.derivation_indices = tracker.txout_index.derivation_indices();
+
+            new_sparsechain
+        }
+        ElectrumCommands::Sync {
+            mut unused,
+            mut unspent,
+            all,
+        } => {
+            let txout_index = &tracker.txout_index;
+            if !(all || unused || unspent) {
+                unused = true;
+                unspent = true;
+            } else if all {
+                unused = false;
+                unspent = false
+            }
+            let mut spks: Box<dyn Iterator<Item = bdk_core::bitcoin::Script>> =
+                Box::new(core::iter::empty());
+            if unused {
+                spks = Box::new(spks.chain(txout_index.unused(..).map(|(index, script)| {
+                    eprintln!("Checking if address at {:?} has been used", index);
+                    script.clone()
+                })));
+            }
+
+            if all {
+                spks = Box::new(spks.chain(txout_index.script_pubkeys().iter().map(
+                    |(index, script)| {
+                        eprintln!("scanning {:?}", index);
+                        script.clone()
+                    },
+                )));
+            }
+
+            if unspent {
+                spks = Box::new(spks.chain(tracker.full_utxos().map(|(_index, ftxout)| {
+                    eprintln!("checking if {} has been spent", ftxout.outpoint);
+                    ftxout.txout.script_pubkey
+                })));
+            }
+
+            // Wallet scan returns a sparse chain that contains new All the BlockIds and Txids
+            // relevant to the wallet, along with keychain index update if required.
+            let new_sparsechain = client
+                .spk_txid_scan(spks, tracker.chain().checkpoints())
+                .context("scanning the blockchain")?;
+
+            new_sparsechain
+        }
+    };
+
+    // Changeset of txids, both new and old.
+    let sparse_chain_changeset = tracker.chain().determine_changeset(&update_chain)?;
+
+    // Only filter for txids that are new to us.
+    let new_txids: Vec<_> = sparse_chain_changeset
+        .txids
+        .iter()
+        // filter the transactions being removed
+        .filter_map(|(txid, index)| Some((txid, (*index)?)))
+        // filter the transactions that have moved but we already have stored
+        .filter(|(txid, index)| Some(index) != tracker.chain().tx_index(**txid))
+        .collect();
+
+    let new_txs = client.batch_transaction_get(new_txids.iter().map(|(txid, _)| *txid))?;
+    changeset.chain_graph.chain = sparse_chain_changeset;
+    changeset.chain_graph.graph.tx.extend(new_txs);
+
+    // Apply the full scan update
+    db.append_changeset(&changeset)?;
+    tracker.apply_changeset(changeset).expect("should succeed");
+
+    Ok(())
+}

--- a/bdk_keychain/src/keychain_txout_index.rs
+++ b/bdk_keychain/src/keychain_txout_index.rs
@@ -145,8 +145,8 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
         self.inner
             .script_pubkeys()
             .range(&(keychain.clone(), u32::MIN)..=&(keychain.clone(), u32::MAX))
+            .next_back()
             .map(|((_, index), _)| *index)
-            .last()
     }
 
     /// Gets the current derivation index for each keychain in the index.
@@ -166,7 +166,8 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     pub fn store_all_up_to(&mut self, keychains: &BTreeMap<K, u32>) -> bool {
         keychains
             .into_iter()
-            .any(|(keychain, index)| self.store_up_to(keychain, *index))
+            .map(|(keychain, index)| self.store_up_to(keychain, *index))
+            .fold(false, |acc, v| acc || v)
     }
 
     /// Derives script pubkeys from the descriptor **up to and including** `up_to` and stores them


### PR DESCRIPTION
### Why?

There are certain benefits to this approach.

1. We can use the existing conflict-resolution logic within `ChainGraph::determine_changeset`.
2. The resultant `change_graph::ChangeSet` structures of the new API methods are "safe" to use when applying into `ChainGraph` and continue to be safe when merged together and then applied.

### Drawbacks

1. We need apply into `ChangeGraph` before persisting.