### PR TITLE
`insert..` methods ensure chain consistency + renaming stuff

### DIFF
--- a/bdk_chain/src/chain_graph.rs
+++ b/bdk_chain/src/chain_graph.rs
@@ -287,7 +287,7 @@ impl<P: ChainPosition> ChainGraph<P> {
     /// in ascending order.
     pub fn transactions_in_chain(&self) -> impl DoubleEndedIterator<Item = (&P, &Transaction)> {
         self.chain
-            .iter_txids()
+            .txids()
             .map(|(pos, txid)| (pos, self.graph.tx(*txid).expect("must exist")))
     }
 

--- a/bdk_chain/src/chain_graph.rs
+++ b/bdk_chain/src/chain_graph.rs
@@ -4,7 +4,6 @@ use crate::{
     tx_graph::{self, TxGraph},
     BlockId, ForEachTxout, FullTxOut, TxHeight,
 };
-use alloc::collections::BTreeMap;
 use bitcoin::{OutPoint, Transaction, TxOut, Txid};
 use core::fmt::Debug;
 
@@ -53,65 +52,105 @@ impl<P: ChainPosition> ChainGraph<P> {
         self.chain.set_checkpoint_limit(limit)
     }
 
-    /// Inserts a transaction into the inner [`ChainGraph`] and optionally into the chain at
-    /// `position`.
-    ///
-    /// If inserting it into a chain `position` will result in a conflict, an error will be returned
-    /// instead.
-    ///
-    /// **Warning**: This function modifies the internal state of the chain graph. You are
-    /// responsible for persisting these changes to disk if you need to restore them.
-    pub fn insert_tx(
-        &mut self,
-        tx: Transaction,
-        position: Option<P>,
-    ) -> Result<bool, InsertTxErr<P>> {
-        // only care about conflicts if chain position is provided
-        if position.is_some() {
-            let conflicts = self
-                .conflicting_txids(&tx)
-                .map(|(k, v)| (k.clone(), v))
-                .collect::<BTreeMap<_, _>>();
-            if !conflicts.is_empty() {
-                return Err(InsertTxErr::Conflicts(conflicts));
-            }
-        }
-
-        let chain_changed = match position {
-            Some(pos) => self.chain.insert_tx(tx.txid(), pos)?,
-            None => false,
-        };
-        let graph_changed = self.graph.insert_tx(tx);
-
-        Ok(graph_changed || chain_changed)
-    }
-
     /// Get a transaction that is currently in the underlying [`SparseChain`]. This doesn't
     /// necessarily mean that it is *confirmed* in the blockchain, it might just be in the
-    /// unconfirmed transaction list within the `SparseChain`.
-    ///
-    /// [`SparseChain`]: crate::sparse_chain::SparseChain
+    /// unconfirmed transaction list within the [`SparseChain`].
     pub fn get_tx_in_chain(&self, txid: Txid) -> Option<(&P, &Transaction)> {
         let position = self.chain.tx_position(txid)?;
         let full_tx = self.graph.tx(txid).expect("must exist");
         Some((position, full_tx))
     }
 
-    pub fn insert_output(&mut self, outpoint: OutPoint, txout: TxOut) -> bool {
-        self.graph.insert_txout(outpoint, txout)
+    /// Determines the changes required to insert a transaction into the inner [`ChainGraph`] and
+    /// [`SparseChain`] at the given `position`.
+    ///
+    /// If inserting it into the chain `position` will result in conflicts, the returned
+    /// [`ChangeSet`] should evict conflicting transactions.
+    pub fn insert_tx_preview(
+        &self,
+        tx: Transaction,
+        pos: P,
+    ) -> Result<ChangeSet<P>, InsertTxFailure<P>> {
+        // only allow displacement of unconfirmed txs
+        let chain_changeset = self.chain.insert_tx_preview(tx.txid(), pos)?;
+
+        Ok(self
+            .inflate_changeset(chain_changeset, core::iter::once(tx))
+            .map_err(|failure| match failure {
+                InflateFailure::Missing(_) => unreachable!("no transaction should be missing"),
+                InflateFailure::UnresolvableConflict(conflict) => {
+                    InsertTxFailure::UnresolvableConflict(conflict)
+                }
+            })?)
     }
 
-    /// Insert a `block_id` (a height and block hash) into the chain. If a checkpoint already exists
-    /// at that height with a different hash this will return an error. Otherwise it will return
-    /// `Ok(true)` if the checkpoint didn't already exist or `Ok(false)` if it did.
+    /// Inserts [`Transaction`] at given chain position. This is equivalent to calling
+    /// [`Self::insert_tx_preview()`] and [`Self::apply_changeset()`] in sequence.
+    pub fn insert_tx(
+        &mut self,
+        tx: Transaction,
+        pos: P,
+    ) -> Result<ChangeSet<P>, InsertTxFailure<P>> {
+        let changeset = self.insert_tx_preview(tx, pos)?;
+        self.apply_changeset(changeset.clone())
+            .expect("changeset should not have missing transactions");
+        Ok(changeset)
+    }
+
+    /// Determines the changes required to insert a [`TxOut`] into the internal [`TxGraph`].
+    pub fn insert_txout_preview(
+        &self,
+        outpoint: OutPoint,
+        txout: TxOut,
+    ) -> Result<ChangeSet<P>, tx_graph::TxOutConflict> {
+        self.graph
+            .insert_txout_preview(outpoint, txout)
+            .map(|additions| ChangeSet {
+                graph: additions,
+                ..Default::default()
+            })
+    }
+
+    /// Inserts a [`TxOut`] into the internal [`TxGraph`]. This is equivalent to calling
+    /// [`Self::insert_txout_preview()`] and [`Self::apply_changeset`] in sequence.
+    pub fn insert_txout(
+        &mut self,
+        outpoint: OutPoint,
+        txout: TxOut,
+    ) -> Result<ChangeSet<P>, tx_graph::TxOutConflict> {
+        let changeset = self.insert_txout_preview(outpoint, txout)?;
+        self.apply_changeset(changeset.clone())
+            .expect("changeset should not have missing transactions");
+        Ok(changeset)
+    }
+
+    /// Determines the changes required to insert a `block_id` (a height and block hash) into the
+    /// chain.
     ///
-    /// **Warning**: This function modifies the internal state of the chain graph. You are
-    /// responsible for persisting these changes to disk if you need to restore them.
+    /// If a checkpoint already exists at that height with a different hash this will return
+    /// an error.
+    pub fn insert_checkpoint_preview(
+        &self,
+        block_id: BlockId,
+    ) -> Result<ChangeSet<P>, InsertCheckpointFailure> {
+        self.chain
+            .insert_checkpoint_preview(block_id)
+            .map(|chain_changeset| ChangeSet {
+                chain: chain_changeset,
+                ..Default::default()
+            })
+    }
+
+    /// Inserts checkpoint into [`Self`]. This is equivilant to calling
+    /// [`Self::insert_checkpoint_preview()`] and [`Self::apply_changeset()] in sequence.
     pub fn insert_checkpoint(
         &mut self,
         block_id: BlockId,
-    ) -> Result<bool, sparse_chain::InsertCheckpointErr> {
-        self.chain.insert_checkpoint(block_id)
+    ) -> Result<ChangeSet<P>, InsertCheckpointFailure> {
+        let changeset = self.insert_checkpoint_preview(block_id)?;
+        self.apply_changeset(changeset.clone())
+            .expect("changeset should not have missing transactions");
+        Ok(changeset)
     }
 
     /// Calculates the difference between self and `update` in the form of a [`ChangeSet`].
@@ -123,7 +162,7 @@ impl<P: ChainPosition> ChainGraph<P> {
 
         let mut changeset = ChangeSet::<P> {
             chain: chain_changeset,
-            graph: self.graph.determine_additions(&update.graph),
+            graph: self.graph.determine_additions(&update.graph)?,
         };
 
         self.fix_conflicts(&mut changeset)?;
@@ -131,9 +170,12 @@ impl<P: ChainPosition> ChainGraph<P> {
         Ok(changeset)
     }
 
-    /// Given a transaction, return an iterator of conflicting [`Txid`]s that are marked within the
-    /// internal chain.
-    pub fn conflicting_txids<'a>(
+    /// Given a transaction, return an iterator of in-chain [`Txid`]s that conflict with it (spends
+    /// at least one of the same inputs).
+    ///
+    /// This method is comparable to [`TxGraph::conflicting_txids()`] which returns all conflicting
+    /// transactions, whereas this method only returns conflicts that exist in the [`SparseChain`].
+    pub fn conflicting_txids_in_chain<'a>(
         &'a self,
         tx: &'a Transaction,
     ) -> impl Iterator<Item = (&'a P, Txid)> + 'a {
@@ -157,15 +199,16 @@ impl<P: ChainPosition> ChainGraph<P> {
             // and are going to be added to the chain
             .filter_map(|(tx, txid)| Some((changeset.chain.txids.get(&txid)?.as_ref()?, txid, tx)))
             .flat_map(|(update_pos, update_txid, update_tx)| {
-                self.conflicting_txids(update_tx)
-                    .map(move |(conflicting_pos, conflicting_txid)| {
+                self.conflicting_txids_in_chain(update_tx).map(
+                    move |(conflicting_pos, conflicting_txid)| {
                         (
                             update_pos.clone(),
                             update_txid,
                             conflicting_pos,
                             conflicting_txid,
                         )
-                    })
+                    },
+                )
             })
             .collect::<alloc::vec::Vec<_>>();
 
@@ -207,7 +250,7 @@ impl<P: ChainPosition> ChainGraph<P> {
         Ok(())
     }
 
-    /// Applies a [`ChangeSet`] to the chain graph
+    /// Applies [`ChangeSet`] to [`Self`]. This fails if there are missing full transactions.
     pub fn apply_changeset(
         &mut self,
         changeset: ChangeSet<P>,
@@ -236,13 +279,13 @@ impl<P: ChainPosition> ChainGraph<P> {
         changeset: sparse_chain::ChangeSet<P>,
         full_txs: impl IntoIterator<Item = Transaction>,
     ) -> Result<ChangeSet<P>, InflateFailure<P>> {
-        let mut missing = self
-            .chain
-            .changeset_additions(&changeset)
-            .collect::<HashSet<_>>();
-        missing.retain(|txid| !self.graph.contains_txid(*txid));
         // need to wrap in a refcell because it's closed over twice below
-        let missing = core::cell::RefCell::new(missing);
+        let missing = core::cell::RefCell::new(
+            self.chain
+                .changeset_additions(&changeset)
+                .filter(|txid| !self.graph.contains_txid(*txid))
+                .collect::<HashSet<_>>(),
+        );
         let full_txs = full_txs
             .into_iter()
             .take_while(|_| !missing.borrow().is_empty())
@@ -266,16 +309,13 @@ impl<P: ChainPosition> ChainGraph<P> {
         }
     }
 
-    /// Applies the `update` chain graph. Note this is shorthand for calling [`determine_changeset`]
-    /// and [`apply_changeset`] in sequence.
-    ///
-    /// [`apply_changeset`]: Self::apply_changeset
-    /// [`determine_changeset`]: Self::determine_changeset
-    pub fn apply_update(&mut self, update: Self) -> Result<(), UpdateFailure<P>> {
+    /// Applies the `update` chain graph. Note this is shorthand for calling
+    /// [`Self::determine_changeset()`] and [`Self::apply_changeset()`] in sequence.
+    pub fn apply_update(&mut self, update: Self) -> Result<ChangeSet<P>, UpdateFailure<P>> {
         let changeset = self.determine_changeset(&update)?;
-        self.apply_changeset(changeset)
+        self.apply_changeset(changeset.clone())
             .expect("we correctly constructed this");
-        Ok(())
+        Ok(changeset)
     }
 
     /// Get the full transaction output at an outpoint if it exists in the chain and the graph.
@@ -305,6 +345,7 @@ impl<P: ChainPosition> ChainGraph<P> {
     derive(serde::Deserialize, serde::Serialize),
     serde(crate = "serde_crate")
 )]
+#[must_use]
 pub struct ChangeSet<P> {
     pub chain: sparse_chain::ChangeSet<P>,
     pub graph: tx_graph::Additions,
@@ -313,6 +354,13 @@ pub struct ChangeSet<P> {
 impl<P> ChangeSet<P> {
     pub fn is_empty(&self) -> bool {
         self.chain.is_empty() && self.graph.is_empty()
+    }
+
+    pub fn contains_eviction(&self) -> bool {
+        self.chain
+            .txids
+            .iter()
+            .any(|(_, new_pos)| new_pos.is_none())
     }
 }
 
@@ -338,37 +386,38 @@ impl<P> ForEachTxout for ChangeSet<P> {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum InsertTxErr<P> {
-    Chain(sparse_chain::InsertTxErr),
-    Conflicts(BTreeMap<P, Txid>),
+pub enum InsertTxFailure<P> {
+    Chain(sparse_chain::InsertTxFailure<P>),
+    UnresolvableConflict(UnresolvableConflict<P>),
 }
 
-impl<P: core::fmt::Debug> core::fmt::Display for InsertTxErr<P> {
+impl<P: core::fmt::Debug> core::fmt::Display for InsertTxFailure<P> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            InsertTxErr::Chain(inner) => core::fmt::Display::fmt(inner, f),
-            InsertTxErr::Conflicts(_) => write!(
-                f,
-                "cannot directly insert conflicting transaction into chaingraph"
-            ),
+            InsertTxFailure::Chain(inner) => core::fmt::Display::fmt(inner, f),
+            InsertTxFailure::UnresolvableConflict(inner) => core::fmt::Display::fmt(inner, f),
         }
     }
 }
 
-impl<P> From<sparse_chain::InsertTxErr> for InsertTxErr<P> {
-    fn from(inner: sparse_chain::InsertTxErr) -> Self {
+impl<P> From<sparse_chain::InsertTxFailure<P>> for InsertTxFailure<P> {
+    fn from(inner: sparse_chain::InsertTxFailure<P>) -> Self {
         Self::Chain(inner)
     }
 }
 
 #[cfg(feature = "std")]
-impl<P: core::fmt::Debug> std::error::Error for InsertTxErr<P> {}
+impl<P: core::fmt::Debug> std::error::Error for InsertTxFailure<P> {}
+
+pub type InsertCheckpointFailure = sparse_chain::InsertCheckpointFailure;
 
 /// Represents an update failure.
 #[derive(Clone, Debug, PartialEq)]
 pub enum UpdateFailure<P> {
     /// The update chain was inconsistent with the existing chain
     Chain(sparse_chain::UpdateFailure<P>),
+    /// The update graph was inconsistent with the existing graph
+    Graph(tx_graph::TxOutConflict),
     /// A transaction in the update spent the same input as an already confirmed transaction
     UnresolvableConflict(UnresolvableConflict<P>),
 }
@@ -376,9 +425,22 @@ pub enum UpdateFailure<P> {
 impl<P: core::fmt::Debug> core::fmt::Display for UpdateFailure<P> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            UpdateFailure::Chain(inner) => core::fmt::Display::fmt(&inner, f),
-            UpdateFailure::UnresolvableConflict(inner) => core::fmt::Display::fmt(&inner, f),
+            UpdateFailure::Chain(inner) => core::fmt::Display::fmt(inner, f),
+            UpdateFailure::Graph(inner) => core::fmt::Display::fmt(inner, f),
+            UpdateFailure::UnresolvableConflict(inner) => core::fmt::Display::fmt(inner, f),
         }
+    }
+}
+
+impl<P> From<sparse_chain::UpdateFailure<P>> for UpdateFailure<P> {
+    fn from(inner: sparse_chain::UpdateFailure<P>) -> Self {
+        Self::Chain(inner)
+    }
+}
+
+impl<P> From<tx_graph::TxOutConflict> for UpdateFailure<P> {
+    fn from(inner: tx_graph::TxOutConflict) -> Self {
+        Self::Graph(inner)
     }
 }
 
@@ -439,6 +501,12 @@ impl<P> From<UnresolvableConflict<P>> for UpdateFailure<P> {
 }
 
 impl<P> From<UnresolvableConflict<P>> for InflateFailure<P> {
+    fn from(inner: UnresolvableConflict<P>) -> Self {
+        Self::UnresolvableConflict(inner)
+    }
+}
+
+impl<P> From<UnresolvableConflict<P>> for InsertTxFailure<P> {
     fn from(inner: UnresolvableConflict<P>) -> Self {
         Self::UnresolvableConflict(inner)
     }

--- a/bdk_chain/src/keychain.rs
+++ b/bdk_chain/src/keychain.rs
@@ -49,6 +49,7 @@ impl<K, I> Default for KeychainScan<K, I> {
         )
     )
 )]
+#[must_use]
 pub struct KeychainChangeSet<K, P> {
     /// The changes in local keychain derivation indices
     pub derivation_indices: BTreeMap<K, u32>,

--- a/bdk_chain/src/keychain/keychain_tracker.rs
+++ b/bdk_chain/src/keychain/keychain_tracker.rs
@@ -137,7 +137,7 @@ where
         &mut self,
         tx: Transaction,
         position: Option<P>,
-    ) -> Result<bool, sparse_chain::InsertTxErr> {
+    ) -> Result<bool, chain_graph::InsertTxErr<P>> {
         let changed = self.chain_graph.insert_tx(tx.clone(), position)?;
         self.txout_index.scan(&tx);
         Ok(changed)

--- a/bdk_chain/src/keychain/keychain_txout_index.rs
+++ b/bdk_chain/src/keychain/keychain_txout_index.rs
@@ -109,10 +109,10 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
 
     /// Generates iterators for the script pubkeys of every keychain.
     ///
-    /// Convienience method for calling [`script_pubkeys_by_keychain`] on each keychain.
+    /// Convienience method for calling [`script_pubkeys_of_keychain`] on each keychain.
     ///
-    /// [`script_pubkeys_by_keychain`]: Self::script_pubkeys_by_keychain
-    pub fn iter_all_script_pubkeys_by_keychain(
+    /// [`script_pubkeys_of_keychain`]: Self::script_pubkeys_of_keychain
+    pub fn script_pubkeys_of_all_keychains(
         &self,
     ) -> BTreeMap<K, impl Iterator<Item = (u32, Script)> + Clone> {
         self.keychains()
@@ -127,7 +127,7 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     }
 
     /// Iterates over the script pubkeys derived and stored by this index under `keychain`
-    pub fn script_pubkeys_by_keychain(
+    pub fn script_pubkeys_of_keychain(
         &self,
         keychain: &K,
     ) -> impl DoubleEndedIterator<Item = (u32, &Script)> {

--- a/bdk_chain/src/sparse_chain.rs
+++ b/bdk_chain/src/sparse_chain.rs
@@ -320,16 +320,16 @@ impl<P: ChainPosition> SparseChain<P> {
     /// Insert an arbitrary txid. This assumes that we have at least one checkpoint and the tx does
     /// not already exist in [`SparseChain`]. Returns a [`ChangeSet`] on success.
     pub fn insert_tx(&mut self, txid: Txid, pos: P) -> Result<bool, InsertTxErr> {
-        let new_height = pos.height();
+        let tx_height = pos.height();
 
-        let latest = self
+        let tip_height = self
             .checkpoints
             .keys()
             .last()
             .cloned()
             .map(TxHeight::Confirmed);
 
-        if new_height.is_confirmed() && (latest.is_none() || new_height > latest.unwrap()) {
+        if tx_height.is_confirmed() && Some(tx_height) > tip_height {
             return Err(InsertTxErr::TxTooHigh);
         }
 

--- a/bdk_chain/src/sparse_chain.rs
+++ b/bdk_chain/src/sparse_chain.rs
@@ -368,9 +368,7 @@ impl<P: ChainPosition> SparseChain<P> {
         Ok(true)
     }
 
-    pub fn iter_txids(
-        &self,
-    ) -> impl DoubleEndedIterator<Item = &(P, Txid)> + ExactSizeIterator + '_ {
+    pub fn txids(&self) -> impl DoubleEndedIterator<Item = &(P, Txid)> + ExactSizeIterator + '_ {
         self.ordered_txids.iter()
     }
 

--- a/bdk_chain/src/tx_graph.rs
+++ b/bdk_chain/src/tx_graph.rs
@@ -90,44 +90,47 @@ impl TxGraph {
         })
     }
 
-    /// Add transaction, returns true when [`TxGraph`] is updated.
-    pub fn insert_tx(&mut self, tx: Transaction) -> bool {
-        let txid = tx.txid();
+    /// Returns the resultant [`Additions`] if the given transaction is inserted. Does not actually
+    /// mutate [`Self`].
+    pub fn insert_tx_preview(&mut self, tx: Transaction) -> Additions {
+        let mut update = Self::default();
+        update.txs.insert(tx.txid(), TxNode::Whole(tx));
 
-        if let Some(TxNode::Whole(old_tx)) = self.txs.insert(txid, TxNode::Whole(tx.clone())) {
-            debug_assert_eq!(old_tx, tx);
-            return false;
-        }
-
-        tx.input
-            .into_iter()
-            .map(|txin| txin.previous_output)
-            // coinbase spends are not to be counted
-            .filter(|outpoint| !outpoint.is_null())
-            .for_each(|outpoint| {
-                self.spends.entry(outpoint).or_default().insert(txid);
-            });
-
-        true
+        self.apply_update(update)
+            .expect("txout should be as expected")
     }
 
-    /// Inserts an auxiliary txout. Returns true if txout is newly added.
-    pub fn insert_txout(&mut self, outpoint: OutPoint, txout: TxOut) -> bool {
-        let tx_entry = self
-            .txs
-            .entry(outpoint.txid)
-            .or_insert_with(TxNode::default);
+    /// Inserts the given transaction into [`Self`].
+    pub fn insert_tx(&mut self, tx: Transaction) -> Additions {
+        let additions = self.insert_tx_preview(tx);
+        self.apply_additions(additions.clone());
+        additions
+    }
 
-        match tx_entry {
-            TxNode::Whole(_) => false,
-            TxNode::Partial(txouts) => match txouts.insert(outpoint.vout as _, txout.clone()) {
-                Some(old_txout) => {
-                    debug_assert_eq!(txout, old_txout);
-                    false
-                }
-                None => true,
-            },
-        }
+    /// Returns the resultant [`Additions`] if the given [`TxOut`] is inserted at [`OutPoint`]. Does
+    /// not actually mutate [`Self`].
+    pub fn insert_txout_preview(
+        &self,
+        outpoint: OutPoint,
+        txout: TxOut,
+    ) -> Result<Additions, TxOutConflict> {
+        let mut update = Self::default();
+        update.txs.insert(
+            outpoint.txid,
+            TxNode::Partial([(outpoint.vout, txout)].into()),
+        );
+        self.determine_additions(&update)
+    }
+
+    /// Inserts the given [`TxOut`] at [`OutPoint`].
+    pub fn insert_txout(
+        &mut self,
+        outpoint: OutPoint,
+        txout: TxOut,
+    ) -> Result<Additions, TxOutConflict> {
+        let additions = self.insert_txout_preview(outpoint, txout)?;
+        self.apply_additions(additions.clone());
+        Ok(additions)
     }
 
     /// Calculates the fee of a given transaction (if we have all relevant data).
@@ -197,55 +200,123 @@ impl TxGraph {
             .filter(move |(_, spend_txid)| spend_txid != &tx.txid())
     }
 
-    /// Extends this graph with another so that `self` becomes the union of the two sets of
-    /// transactions.
-    pub fn apply_update(&mut self, update: TxGraph) {
-        let additions = self.determine_additions(&update);
-        self.apply_additions(additions);
-    }
-
-    pub fn determine_additions(&self, update: &TxGraph) -> Additions {
+    /// Previews the resultant [`Additions`] when [`Self`] is updated against the `update` graph.
+    pub fn determine_additions(&self, update: &Self) -> Result<Additions, TxOutConflict> {
         let mut additions = Additions::default();
 
-        for (&txid, tx) in &update.txs {
-            match tx {
+        for (&txid, update_tx) in &update.txs {
+            match update_tx {
                 TxNode::Whole(tx) => {
-                    if self.tx(txid).is_none() {
+                    if matches!(self.txs.get(&txid), None | Some(TxNode::Partial(_))) {
                         additions.tx.insert(tx.clone());
                     }
                 }
                 TxNode::Partial(partial) => {
-                    for (&vout, txout) in partial {
-                        let op = OutPoint { txid, vout };
+                    for (&vout, update_txout) in partial {
+                        let outpoint = OutPoint::new(txid, vout);
+
                         let insert = match self.txouts(txid) {
                             Some(txouts) => match txouts.get(&vout) {
-                                Some(existing_txout) => *existing_txout != txout,
+                                Some(&original_txout) if original_txout != update_txout => {
+                                    return Err(TxOutConflict {
+                                        outpoint,
+                                        original_txout: original_txout.clone(),
+                                        update_txout: update_txout.clone(),
+                                    });
+                                }
+                                Some(_) => false,
                                 None => true,
                             },
                             None => true,
                         };
 
                         if insert {
-                            additions.txout.insert(op, txout.clone());
+                            additions
+                                .txout
+                                .insert(OutPoint { txid, vout }, update_txout.clone());
                         }
                     }
                 }
             }
         }
 
-        additions
+        Ok(additions)
+    }
+
+    /// Extends this graph with another so that `self` becomes the union of the two sets of
+    /// transactions.
+    pub fn apply_update(&mut self, update: TxGraph) -> Result<Additions, TxOutConflict> {
+        let additions = self.determine_additions(&update)?;
+        self.apply_additions(additions.clone());
+        Ok(additions)
     }
 
     pub fn apply_additions(&mut self, additions: Additions) {
         for tx in additions.tx {
-            self.insert_tx(tx);
+            let txid = tx.txid();
+
+            tx.input
+                .iter()
+                .map(|txin| txin.previous_output)
+                // coinbase spends are not to be counted
+                .filter(|outpoint| !outpoint.is_null())
+                // record spend as this tx has spent this outpoint
+                .for_each(|outpoint| {
+                    self.spends.entry(outpoint).or_default().insert(txid);
+                });
+
+            if let Some(TxNode::Whole(old_tx)) = self.txs.insert(txid, TxNode::Whole(tx)) {
+                debug_assert_eq!(
+                    old_tx.txid(),
+                    txid,
+                    "old tx of same txid should not be different"
+                );
+            }
         }
 
-        for (outpoint, txout) in &additions.txout {
-            self.insert_txout(*outpoint, txout.clone());
+        for (outpoint, txout) in additions.txout {
+            let tx_entry = self
+                .txs
+                .entry(outpoint.txid)
+                .or_insert_with(TxNode::default);
+
+            match tx_entry {
+                TxNode::Whole(_) => {
+                    debug_assert!(
+                        false,
+                        "graph additions must not replace whole tx with partial"
+                    );
+                }
+                TxNode::Partial(txouts) => {
+                    debug_assert!(
+                        !matches!(txouts.get(&outpoint.vout), Some(original_txout) if original_txout != &txout),
+                        "txout addition should not have different txout of same outpoint"
+                    );
+                    txouts.insert(outpoint.vout, txout);
+                }
+            }
         }
     }
 }
+
+/// Failure case that occurs when a [`TxOut`] is inserted at a given [`OutPoint`] in which a
+/// non-matching [`TxOut`] already exists.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TxOutConflict {
+    pub outpoint: OutPoint,
+    pub original_txout: TxOut,
+    pub update_txout: TxOut,
+}
+
+impl core::fmt::Display for TxOutConflict {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "cannot insert txout ({:?}) at outpoint ({}) as this replaces a non-matching txout ({:?})",
+            self.update_txout, self.outpoint, self.original_txout)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for TxOutConflict {}
 
 #[derive(Debug, Clone, Default, PartialEq)]
 #[cfg_attr(
@@ -253,6 +324,7 @@ impl TxGraph {
     derive(serde::Deserialize, serde::Serialize),
     serde(crate = "serde_crate")
 )]
+#[must_use]
 pub struct Additions {
     pub tx: BTreeSet<Transaction>,
     pub txout: BTreeMap<OutPoint, TxOut>,

--- a/bdk_chain/src/tx_graph.rs
+++ b/bdk_chain/src/tx_graph.rs
@@ -148,7 +148,7 @@ impl TxGraph {
     }
 
     /// Iterate over all tx outputs known by [`TxGraph`].
-    pub fn iter_all_txouts(&self) -> impl Iterator<Item = (OutPoint, &TxOut)> {
+    pub fn all_txouts(&self) -> impl Iterator<Item = (OutPoint, &TxOut)> {
         self.txs.iter().flat_map(|(txid, tx)| match tx {
             TxNode::Whole(tx) => tx
                 .output
@@ -164,14 +164,14 @@ impl TxGraph {
     }
 
     /// Iterate over all full transactions in the graph
-    pub fn iter_full_transactions(&self) -> impl Iterator<Item = &Transaction> {
+    pub fn full_transactions(&self) -> impl Iterator<Item = &Transaction> {
         self.txs.iter().filter_map(|(_, tx)| match tx {
             TxNode::Whole(tx) => Some(tx),
             TxNode::Partial(_) => None,
         })
     }
 
-    pub fn iter_partial_transactions(&self) -> impl Iterator<Item = (Txid, &BTreeMap<u32, TxOut>)> {
+    pub fn partial_transactions(&self) -> impl Iterator<Item = (Txid, &BTreeMap<u32, TxOut>)> {
         self.txs.iter().filter_map(|(txid, tx)| match tx {
             TxNode::Whole(_) => None,
             TxNode::Partial(partial) => Some((*txid, partial)),
@@ -289,7 +289,7 @@ impl Additions {
 
 impl<T: AsRef<TxGraph>> ForEachTxout for T {
     fn for_each_txout(&self, f: &mut impl FnMut((OutPoint, &TxOut))) {
-        self.as_ref().iter_all_txouts().for_each(f)
+        self.as_ref().all_txouts().for_each(f)
     }
 }
 

--- a/bdk_chain/tests/common/mod.rs
+++ b/bdk_chain/tests/common/mod.rs
@@ -15,7 +15,7 @@ macro_rules! chain {
 
         $(
             $(
-                chain.insert_tx($txid, $tx_height).unwrap();
+                let _ = chain.insert_tx($txid, $tx_height).expect("should succeed");
             )*
         )?
 

--- a/bdk_chain/tests/test_chain_graph.rs
+++ b/bdk_chain/tests/test_chain_graph.rs
@@ -46,16 +46,21 @@ fn test_spent_by() {
     };
 
     let mut cg1 = ChainGraph::default();
-    cg1.insert_tx(tx1, Some(TxHeight::Unconfirmed)).unwrap();
+    let _ = cg1
+        .insert_tx(tx1, TxHeight::Unconfirmed)
+        .expect("should insert");
     let mut cg2 = cg1.clone();
-    cg1.insert_tx(tx2.clone(), Some(TxHeight::Unconfirmed))
-        .unwrap();
-    cg2.insert_tx(tx3.clone(), Some(TxHeight::Unconfirmed))
-        .unwrap();
-    // put the these txs in the graph but not in chain. `spent_by` should return the one that was
-    // actually in the respective chain.
-    cg1.insert_tx(tx3.clone(), None).expect("should insert");
-    cg2.insert_tx(tx2.clone(), None).expect("should insert");
+    let _ = cg1
+        .insert_tx(tx2.clone(), TxHeight::Unconfirmed)
+        .expect("should insert");
+    let _ = cg2
+        .insert_tx(tx3.clone(), TxHeight::Unconfirmed)
+        .expect("should insert");
+
+    // // put the these txs in the graph but not in chain. `spent_by` should return the one that was
+    // // actually in the respective chain.
+    // cg1.insert_tx(tx3.clone(), None).expect("should insert");
+    // cg2.insert_tx(tx2.clone(), None).expect("should insert");
 
     assert_eq!(cg1.spent_by(op), Some((&TxHeight::Unconfirmed, tx2.txid())));
     assert_eq!(cg2.spent_by(op), Some((&TxHeight::Unconfirmed, tx3.txid())));
@@ -109,16 +114,19 @@ fn update_evicts_conflicting_tx() {
     {
         let mut cg1 = {
             let mut cg = ChainGraph::default();
-            cg.insert_checkpoint(cp_a).expect("should insert cp");
-            cg.insert_tx(tx_a.clone(), Some(TxHeight::Confirmed(0)))
+            let _ = cg.insert_checkpoint(cp_a).expect("should insert cp");
+            let _ = cg
+                .insert_tx(tx_a.clone(), TxHeight::Confirmed(0))
                 .expect("should insert tx");
-            cg.insert_tx(tx_b.clone(), Some(TxHeight::Unconfirmed))
+            let _ = cg
+                .insert_tx(tx_b.clone(), TxHeight::Unconfirmed)
                 .expect("should insert tx");
             cg
         };
         let cg2 = {
             let mut cg = ChainGraph::default();
-            cg.insert_tx(tx_b2.clone(), Some(TxHeight::Unconfirmed))
+            let _ = cg
+                .insert_tx(tx_b2.clone(), TxHeight::Unconfirmed)
                 .expect("should insert tx");
             cg
         };
@@ -149,17 +157,20 @@ fn update_evicts_conflicting_tx() {
     {
         let cg1 = {
             let mut cg = ChainGraph::default();
-            cg.insert_checkpoint(cp_a).expect("should insert cp");
-            cg.insert_checkpoint(cp_b).expect("should insert cp");
-            cg.insert_tx(tx_a.clone(), Some(TxHeight::Confirmed(0)))
+            let _ = cg.insert_checkpoint(cp_a).expect("should insert cp");
+            let _ = cg.insert_checkpoint(cp_b).expect("should insert cp");
+            let _ = cg
+                .insert_tx(tx_a.clone(), TxHeight::Confirmed(0))
                 .expect("should insert tx");
-            cg.insert_tx(tx_b.clone(), Some(TxHeight::Confirmed(1)))
+            let _ = cg
+                .insert_tx(tx_b.clone(), TxHeight::Confirmed(1))
                 .expect("should insert tx");
             cg
         };
         let cg2 = {
             let mut cg = ChainGraph::default();
-            cg.insert_tx(tx_b2.clone(), Some(TxHeight::Unconfirmed))
+            let _ = cg
+                .insert_tx(tx_b2.clone(), TxHeight::Unconfirmed)
                 .expect("should insert tx");
             cg
         };
@@ -179,19 +190,22 @@ fn update_evicts_conflicting_tx() {
         // introduced in the update to be successfully evicted.
         let mut cg1 = {
             let mut cg = ChainGraph::default();
-            cg.insert_checkpoint(cp_a).expect("should insert cp");
-            cg.insert_checkpoint(cp_b).expect("should insert cp");
-            cg.insert_tx(tx_a.clone(), Some(TxHeight::Confirmed(0)))
+            let _ = cg.insert_checkpoint(cp_a).expect("should insert cp");
+            let _ = cg.insert_checkpoint(cp_b).expect("should insert cp");
+            let _ = cg
+                .insert_tx(tx_a.clone(), TxHeight::Confirmed(0))
                 .expect("should insert tx");
-            cg.insert_tx(tx_b.clone(), Some(TxHeight::Confirmed(1)))
+            let _ = cg
+                .insert_tx(tx_b.clone(), TxHeight::Confirmed(1))
                 .expect("should insert tx");
             cg
         };
         let cg2 = {
             let mut cg = ChainGraph::default();
-            cg.insert_checkpoint(cp_a).expect("should insert cp");
-            cg.insert_checkpoint(cp_b2).expect("should insert cp");
-            cg.insert_tx(tx_b2.clone(), Some(TxHeight::Unconfirmed))
+            let _ = cg.insert_checkpoint(cp_a).expect("should insert cp");
+            let _ = cg.insert_checkpoint(cp_b2).expect("should insert cp");
+            let _ = cg
+                .insert_tx(tx_b2.clone(), TxHeight::Unconfirmed)
                 .expect("should insert tx");
             cg
         };
@@ -350,11 +364,10 @@ fn test_get_tx_in_chain() {
         output: vec![TxOut::default()],
     };
 
-    cg.insert_tx(tx.clone(), None).unwrap();
-    assert_eq!(cg.get_tx_in_chain(tx.txid()), None);
+    // cg.insert_tx(tx.clone(), None).unwrap();
+    // assert_eq!(cg.get_tx_in_chain(tx.txid()), None);
 
-    cg.insert_tx(tx.clone(), Some(TxHeight::Unconfirmed))
-        .unwrap();
+    let _ = cg.insert_tx(tx.clone(), TxHeight::Unconfirmed).unwrap();
     assert_eq!(
         cg.get_tx_in_chain(tx.txid()),
         Some((&TxHeight::Unconfirmed, &tx))
@@ -372,16 +385,18 @@ fn test_iterate_transactions() {
             output: vec![TxOut::default()],
         })
         .collect::<Vec<_>>();
-    cg.insert_checkpoint(BlockId {
-        height: 1,
-        hash: h!("A"),
-    })
-    .unwrap();
-    cg.insert_tx(txs[0].clone(), Some(TxHeight::Confirmed(1)))
+    let _ = cg
+        .insert_checkpoint(BlockId {
+            height: 1,
+            hash: h!("A"),
+        })
         .unwrap();
-    cg.insert_tx(txs[1].clone(), Some(TxHeight::Unconfirmed))
+    let _ = cg
+        .insert_tx(txs[0].clone(), TxHeight::Confirmed(1))
         .unwrap();
-    cg.insert_tx(txs[2].clone(), Some(TxHeight::Confirmed(0)))
+    let _ = cg.insert_tx(txs[1].clone(), TxHeight::Unconfirmed).unwrap();
+    let _ = cg
+        .insert_tx(txs[2].clone(), TxHeight::Confirmed(0))
         .unwrap();
 
     assert_eq!(

--- a/bdk_chain/tests/test_chain_graph.rs
+++ b/bdk_chain/tests/test_chain_graph.rs
@@ -57,11 +57,6 @@ fn test_spent_by() {
         .insert_tx(tx3.clone(), TxHeight::Unconfirmed)
         .expect("should insert");
 
-    // // put the these txs in the graph but not in chain. `spent_by` should return the one that was
-    // // actually in the respective chain.
-    // cg1.insert_tx(tx3.clone(), None).expect("should insert");
-    // cg2.insert_tx(tx2.clone(), None).expect("should insert");
-
     assert_eq!(cg1.spent_by(op), Some((&TxHeight::Unconfirmed, tx2.txid())));
     assert_eq!(cg2.spent_by(op), Some((&TxHeight::Unconfirmed, tx3.txid())));
 }
@@ -363,9 +358,6 @@ fn test_get_tx_in_chain() {
         input: vec![],
         output: vec![TxOut::default()],
     };
-
-    // cg.insert_tx(tx.clone(), None).unwrap();
-    // assert_eq!(cg.get_tx_in_chain(tx.txid()), None);
 
     let _ = cg.insert_tx(tx.clone(), TxHeight::Unconfirmed).unwrap();
     assert_eq!(

--- a/bdk_chain/tests/test_keychain_tracker.rs
+++ b/bdk_chain/tests/test_keychain_tracker.rs
@@ -28,9 +28,6 @@ fn test_insert_tx() {
     };
 
     assert!(tracker.txout_index.store_up_to(&(), 5));
-    // tracker
-    //     .insert_tx(tx.clone(), ConfirmationTime::Unconfirmed)
-    //     .unwrap();
     let changeset = tracker
         .insert_tx_preview(tx.clone(), ConfirmationTime::Unconfirmed)
         .unwrap();

--- a/bdk_chain/tests/test_keychain_tracker.rs
+++ b/bdk_chain/tests/test_keychain_tracker.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "miniscript")]
+
 use bdk_chain::{
     keychain::KeychainTracker,
     miniscript::{
@@ -27,9 +28,13 @@ fn test_insert_tx() {
     };
 
     assert!(tracker.txout_index.store_up_to(&(), 5));
-    tracker
-        .insert_tx(tx.clone(), Some(ConfirmationTime::Unconfirmed))
+    // tracker
+    //     .insert_tx(tx.clone(), ConfirmationTime::Unconfirmed)
+    //     .unwrap();
+    let changeset = tracker
+        .insert_tx_preview(tx.clone(), ConfirmationTime::Unconfirmed)
         .unwrap();
+    tracker.apply_changeset(changeset).unwrap();
     assert_eq!(
         tracker
             .chain_graph()

--- a/bdk_chain/tests/test_keychain_txout_index.rs
+++ b/bdk_chain/tests/test_keychain_txout_index.rs
@@ -1,9 +1,7 @@
 #![cfg(feature = "miniscript")]
-use bdk_chain::collections::BTreeMap;
 
-use bdk_chain::keychain::KeychainTxOutIndex;
+use bdk_chain::collections::BTreeMap;
 use bitcoin::{OutPoint, TxOut};
-use miniscript::{Descriptor, DescriptorPublicKey};
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 enum TestKeychain {
@@ -11,8 +9,10 @@ enum TestKeychain {
     Internal,
 }
 
-fn init_txout_index() -> KeychainTxOutIndex<TestKeychain> {
-    let mut txout_index = KeychainTxOutIndex::<TestKeychain>::default();
+fn init_txout_index() -> bdk_chain::keychain::KeychainTxOutIndex<TestKeychain> {
+    use miniscript::{Descriptor, DescriptorPublicKey};
+
+    let mut txout_index = bdk_chain::keychain::KeychainTxOutIndex::<TestKeychain>::default();
 
     let secp = bdk_chain::bitcoin::secp256k1::Secp256k1::signing_only();
     let (external_descriptor,_) = Descriptor::<DescriptorPublicKey>::parse_descriptor(&secp, "tr([73c5da0a/86'/0'/0']xprv9xgqHN7yz9MwCkxsBPN5qetuNdQSUttZNKw1dcYTV4mkaAFiBVGQziHs3NRSWMkCzvgjEe3n9xV8oYywvM8at9yRqyaZVz6TYYhX98VjsUk/0/*)").unwrap();

--- a/bdk_chain/tests/test_sparse_chain.rs
+++ b/bdk_chain/tests/test_sparse_chain.rs
@@ -752,3 +752,22 @@ fn invalidated_txs_move_to_unconfirmed() {
         },)
     );
 }
+
+#[test]
+fn change_tx_position_from_unconfirmed_to_confirmed() {
+    let mut chain = SparseChain::<TxHeight>::default();
+    let txid = h!("txid");
+
+    let _ = chain.insert_tx(txid, TxHeight::Unconfirmed).unwrap();
+
+    assert_eq!(chain.tx_position(txid), Some(&TxHeight::Unconfirmed));
+    let _ = chain
+        .insert_checkpoint(BlockId {
+            height: 0,
+            hash: h!("0"),
+        })
+        .unwrap();
+    let _ = chain.insert_tx(txid, TxHeight::Confirmed(0)).unwrap();
+
+    assert_eq!(chain.tx_position(txid), Some(&TxHeight::Confirmed(0)));
+}

--- a/bdk_chain/tests/test_tx_graph.rs
+++ b/bdk_chain/tests/test_tx_graph.rs
@@ -61,9 +61,9 @@ fn insert_txouts() {
     );
 
     graph.apply_additions(additions);
-    assert_eq!(graph.iter_all_txouts().count(), 3);
-    assert_eq!(graph.iter_full_transactions().count(), 0);
-    assert_eq!(graph.iter_partial_transactions().count(), 2);
+    assert_eq!(graph.all_txouts().count(), 3);
+    assert_eq!(graph.full_transactions().count(), 0);
+    assert_eq!(graph.partial_transactions().count(), 2);
 }
 
 #[test]

--- a/bdk_chain/tests/test_tx_graph.rs
+++ b/bdk_chain/tests/test_tx_graph.rs
@@ -37,7 +37,15 @@ fn insert_txouts() {
     let mut graph = {
         let mut graph = TxGraph::default();
         for (outpoint, txout) in &original_ops {
-            assert!(graph.insert_txout(*outpoint, txout.clone()));
+            assert_eq!(
+                graph
+                    .insert_txout(*outpoint, txout.clone())
+                    .expect("should not conflict"),
+                Additions {
+                    txout: [(*outpoint, txout.clone())].into(),
+                    ..Default::default()
+                }
+            );
         }
         graph
     };
@@ -45,12 +53,22 @@ fn insert_txouts() {
     let update = {
         let mut graph = TxGraph::default();
         for (outpoint, txout) in &update_ops {
-            assert!(graph.insert_txout(*outpoint, txout.clone()));
+            assert_eq!(
+                graph
+                    .insert_txout(*outpoint, txout.clone())
+                    .expect("should not conflict"),
+                Additions {
+                    txout: [(*outpoint, txout.clone())].into(),
+                    ..Default::default()
+                }
+            );
         }
         graph
     };
 
-    let additions = graph.determine_additions(&update);
+    let additions = graph
+        .determine_additions(&update)
+        .expect("should not conflict");
 
     assert_eq!(
         additions,
@@ -79,7 +97,7 @@ fn insert_tx_graph_doesnt_count_coinbase_as_spent() {
     };
 
     let mut graph = TxGraph::default();
-    graph.insert_tx(tx);
+    let _ = graph.insert_tx(tx);
     assert!(graph.outspends(OutPoint::null()).is_empty());
     assert!(graph.tx_outspends(Txid::all_zeros()).next().is_none());
 }
@@ -112,11 +130,11 @@ fn insert_tx_graph_keeps_track_of_spend() {
     let mut graph2 = TxGraph::default();
 
     // insert in different order
-    graph1.insert_tx(tx1.clone());
-    graph1.insert_tx(tx2.clone());
+    let _ = graph1.insert_tx(tx1.clone());
+    let _ = graph1.insert_tx(tx2.clone());
 
-    graph2.insert_tx(tx2.clone());
-    graph2.insert_tx(tx1.clone());
+    let _ = graph2.insert_tx(tx2.clone());
+    let _ = graph2.insert_tx(tx1.clone());
 
     assert_eq!(
         &*graph1.outspends(op),
@@ -138,6 +156,6 @@ fn insert_tx_can_retrieve_full_tx_from_graph() {
     };
 
     let mut graph = TxGraph::default();
-    graph.insert_tx(tx.clone());
+    let _ = graph.insert_tx(tx.clone());
     assert_eq!(graph.tx(tx.txid()), Some(&tx));
 }

--- a/bdk_cli_lib/src/lib.rs
+++ b/bdk_cli_lib/src/lib.rs
@@ -206,7 +206,7 @@ where
                 true => Keychain::Internal,
                 false => Keychain::External,
             };
-            for (index, spk) in txout_index.script_pubkeys_by_keychain(&target_keychain) {
+            for (index, spk) in txout_index.script_pubkeys_of_keychain(&target_keychain) {
                 let address = Address::from_script(&spk, network)
                     .expect("should always be able to derive address");
                 println!(

--- a/bdk_electrum_example/src/main.rs
+++ b/bdk_electrum_example/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> anyhow::Result<()> {
         } => {
             let scripts = tracker
                 .txout_index
-                .iter_all_script_pubkeys_by_keychain()
+                .script_pubkeys_of_all_keychains()
                 .into_iter()
                 .map(|(keychain, iter)| {
                     let mut first = true;

--- a/bdk_esplora_example/src/esplora.rs
+++ b/bdk_esplora_example/src/esplora.rs
@@ -1,9 +1,8 @@
 use bdk_chain::{
     bitcoin::{BlockHash, Script, Transaction},
-    chain_graph::{ChainGraph, InsertTxErr},
+    chain_graph::ChainGraph,
     keychain::KeychainScan,
-    sparse_chain::{self, InsertCheckpointErr},
-    BlockId, ConfirmationTime,
+    sparse_chain, BlockId, ConfirmationTime,
 };
 use esplora_client::{BlockingClient, Builder};
 use std::collections::BTreeMap;
@@ -79,16 +78,15 @@ impl Client {
         let mut wallet_scan = KeychainScan::default();
         let update = &mut wallet_scan.update;
 
-        for (&existing_height, &existing_hash) in local_chain.iter().rev() {
-            let current_hash = self.client.get_block_hash(existing_height)?;
-            update
-                .insert_checkpoint(BlockId {
-                    height: existing_height,
-                    hash: current_hash,
-                })
+        for (&height, &original_hash) in local_chain.iter().rev() {
+            let update_block_id = BlockId {
+                height,
+                hash: self.client.get_block_hash(height)?,
+            };
+            let _ = update
+                .insert_checkpoint(update_block_id)
                 .expect("should not collide");
-
-            if current_hash == existing_hash {
+            if update_block_id.hash == original_hash {
                 break;
             }
         }
@@ -97,9 +95,9 @@ impl Client {
             height: self.client.get_height()?,
             hash: self.client.get_tip_hash()?,
         };
-        if let Err(err) = update.insert_checkpoint(tip_at_start) {
-            match err {
-                InsertCheckpointErr::HashNotMatching => {
+        if let Err(failure) = update.insert_checkpoint(tip_at_start) {
+            match failure {
+                sparse_chain::InsertCheckpointFailure::HashNotMatching { .. } => {
                     /* There has been a reorg since the line of code above, we will catch this later on */
                 }
             }
@@ -163,16 +161,19 @@ impl Client {
                             },
                             false => ConfirmationTime::Unconfirmed,
                         };
-                        if let Err(err) = update.insert_tx(tx.to_tx(), Some(confirmation_time)) {
-                            match err {
-                                InsertTxErr::Chain(sparse_chain::InsertTxErr::TxTooHigh) => {
-                                    /* Don't care about new transactions confirmed while syncing */
+                        if let Err(failure) = update.insert_tx(tx.to_tx(), confirmation_time) {
+                            use bdk_chain::{
+                                chain_graph::InsertTxFailure, sparse_chain::InsertTxFailure::*,
+                            };
+                            match failure {
+                                InsertTxFailure::Chain(TxTooHigh { .. }) => {
+                                    /* Chain tip has increased, ignore tx for now */
                                 }
-                                InsertTxErr::Chain(sparse_chain::InsertTxErr::TxMoved) => {
-                                    /* This means there is a reorg, we will catch that below */
+                                InsertTxFailure::Chain(TxMovedUnexpectedly { .. }) => {
+                                    /* Reorg occured (catch error below), ignore tx for now */
                                 }
-                                InsertTxErr::Conflicts(_) => {
-                                    /* This means there is a reorg, we will catch that below */
+                                InsertTxFailure::UnresolvableConflict(_) => {
+                                    /* Reorg occured (catch error below), ignore tx for now */
                                 }
                             }
                         }
@@ -194,18 +195,14 @@ impl Client {
         // Depending upon service providers number of recent blocks returned will vary.
         // esplora returns 10.
         // mempool.space returns 15.
-        for block in self
-            .client
-            .get_recent_blocks(None)?
-            .iter()
-            .map(|esplora_block| BlockId {
-                height: esplora_block.height,
-                hash: esplora_block.id,
-            })
-        {
-            if update.insert_checkpoint(block).is_err() {
-                return Err(UpdateError::Reorg);
-            }
+        for block in self.client.get_recent_blocks(None)? {
+            let block_id = BlockId {
+                height: block.height,
+                hash: block.id,
+            };
+            let _ = update
+                .insert_checkpoint(block_id)
+                .map_err(|_| UpdateError::Reorg)?;
         }
 
         Ok(wallet_scan)

--- a/bdk_esplora_example/src/main.rs
+++ b/bdk_esplora_example/src/main.rs
@@ -61,7 +61,7 @@ fn main() -> anyhow::Result<()> {
         EsploraCommands::Scan { stop_gap } => {
             let spk_iterators = keychain_tracker
                 .txout_index
-                .iter_all_script_pubkeys_by_keychain()
+                .script_pubkeys_of_all_keychains()
                 .into_iter()
                 .map(|(keychain, iter)| {
                     let mut first = true;

--- a/bdk_esplora_example/src/main.rs
+++ b/bdk_esplora_example/src/main.rs
@@ -87,11 +87,8 @@ fn main() -> anyhow::Result<()> {
                 .context("scanning the blockchain")?;
             eprintln!();
 
-            let changeset = keychain_tracker.determine_changeset(&wallet_scan)?;
+            let changeset = keychain_tracker.apply_update(wallet_scan)?;
             db.append_changeset(&changeset)?;
-            keychain_tracker
-                .apply_changeset(changeset)
-                .expect("it was just generated");
         }
         EsploraCommands::Sync {
             mut unused,


### PR DESCRIPTION
Closes #97 
Closes #90 
Closes #110 

**Chain consistency stuff**

Methods such as `insert_{}` are split between `insert_{}_preview` and `insert_{}`. One only previews the changes, the latter also applies. Both these methods returns a changeset.

The internal logic of `insert_{}_preview` now uses as `determine_changeset` to make behavior more reliable and reduce duplicated code. This means that any changes are consistent with the logic of `determine_changeset/additions`.

**Renaming stuff**

* Renamed `KeychainTxOutIndex::derive_next_unused` to `next_unused`.
* Remove `iter_` prefixes from methods.