### PR TITLE
Fix derive_next_unused

### DIFF
--- a/bdk_chain/src/keychain/keychain_txout_index.rs
+++ b/bdk_chain/src/keychain/keychain_txout_index.rs
@@ -245,7 +245,7 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     /// ## Panics
     ///
     /// Panics if `keychain` has never been added to the index
-    pub fn derive_next_unused(&mut self, keychain: &K) -> (u32, &Script) {
+    pub fn next_unused(&mut self, keychain: &K) -> (u32, &Script) {
         let need_new = self.keychain_unused(keychain).next().is_none();
         // this rather strange branch is needed because of some lifetime issues
         if need_new {

--- a/bdk_cli_lib/src/lib.rs
+++ b/bdk_cli_lib/src/lib.rs
@@ -175,7 +175,7 @@ where
     let txout_index = &mut keychain_tracker.txout_index;
 
     let new_address = match addr_cmd {
-        AddressCmd::Next => Some(txout_index.derive_next_unused(&Keychain::External)),
+        AddressCmd::Next => Some(txout_index.next_unused(&Keychain::External)),
         AddressCmd::New => Some(txout_index.derive_new(&Keychain::External)),
         _ => None,
     };
@@ -319,9 +319,7 @@ pub fn create_tx<P: ChainPosition>(
     };
 
     let (change_index, change_script) = {
-        let (index, script) = keychain_tracker
-            .txout_index
-            .derive_next_unused(&internal_keychain);
+        let (index, script) = keychain_tracker.txout_index.next_unused(&internal_keychain);
         (index, script.clone())
     };
     let change_plan = bdk_tmp_plan::plan_satisfaction(


### PR DESCRIPTION
Fixes #110 

I think there was an internal logic problem previously where we were calling `next` twice. Once to check if next is available, and then in the return call in `else` block. This would progress the iterator twice on each call..

Restructured the logic to only call `next` once, and also solve the lifetime problem. This also allows us to remove redundant `clone`s elsewhere.

Renamed `derive_next_unused` to `next_unused`. 