### PR TITLE
Make TxGraph::calculate_fee return 0 for coinbase

### DIFF
--- a/bdk_chain/tests/test_tx_graph.rs
+++ b/bdk_chain/tests/test_tx_graph.rs
@@ -267,7 +267,7 @@ fn insert_txout_does_not_displace_tx() {
 }
 
 #[test]
-fn test_calcualte_fee() {
+fn test_calculate_fee() {
     let mut graph = TxGraph::default();
     let intx1 = Transaction {
         version: 0x01,
@@ -299,9 +299,9 @@ fn test_calcualte_fee() {
         },
     );
 
-    graph.insert_tx(intx1.clone());
-    graph.insert_tx(intx2.clone());
-    graph.insert_txout(intxout1.0, intxout1.1);
+    let _ = graph.insert_tx(intx1.clone());
+    let _ = graph.insert_tx(intx2.clone());
+    let _ = graph.insert_txout(intxout1.0, intxout1.1);
 
     let mut tx = Transaction {
         version: 0x01,
@@ -337,11 +337,8 @@ fn test_calcualte_fee() {
     tx.input.remove(2);
 
     // fee would be negative
-    assert_eq!(graph.calculate_fee(&tx), None);
+    assert_eq!(graph.calculate_fee(&tx), Some(-200));
 }
-
-#[test]
-fn test_calculate_fee_negative_fee() {}
 
 #[test]
 fn test_calculate_fee_on_coinbase() {

--- a/bdk_chain/tests/test_tx_graph.rs
+++ b/bdk_chain/tests/test_tx_graph.rs
@@ -265,3 +265,97 @@ fn insert_txout_does_not_displace_tx() {
         None
     );
 }
+
+#[test]
+fn test_calcualte_fee() {
+    let mut graph = TxGraph::default();
+    let intx1 = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(0),
+        input: vec![],
+        output: vec![TxOut {
+            value: 100,
+            ..Default::default()
+        }],
+    };
+    let intx2 = Transaction {
+        version: 0x02,
+        lock_time: PackedLockTime(0),
+        input: vec![],
+        output: vec![TxOut {
+            value: 200,
+            ..Default::default()
+        }],
+    };
+
+    let intxout1 = (
+        OutPoint {
+            txid: h!("dangling output"),
+            vout: 0,
+        },
+        TxOut {
+            value: 300,
+            ..Default::default()
+        },
+    );
+
+    graph.insert_tx(intx1.clone());
+    graph.insert_tx(intx2.clone());
+    graph.insert_txout(intxout1.0, intxout1.1);
+
+    let mut tx = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(0),
+        input: vec![
+            TxIn {
+                previous_output: OutPoint {
+                    txid: intx1.txid(),
+                    vout: 0,
+                },
+                ..Default::default()
+            },
+            TxIn {
+                previous_output: OutPoint {
+                    txid: intx2.txid(),
+                    vout: 0,
+                },
+                ..Default::default()
+            },
+            TxIn {
+                previous_output: intxout1.0,
+                ..Default::default()
+            },
+        ],
+        output: vec![TxOut {
+            value: 500,
+            ..Default::default()
+        }],
+    };
+
+    assert_eq!(graph.calculate_fee(&tx), Some(100));
+
+    tx.input.remove(2);
+
+    // fee would be negative
+    assert_eq!(graph.calculate_fee(&tx), None);
+}
+
+#[test]
+fn test_calculate_fee_negative_fee() {}
+
+#[test]
+fn test_calculate_fee_on_coinbase() {
+    let tx = Transaction {
+        version: 0x01,
+        lock_time: PackedLockTime(0),
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            ..Default::default()
+        }],
+        output: vec![TxOut::default()],
+    };
+
+    let graph = TxGraph::default();
+
+    assert_eq!(graph.calculate_fee(&tx), Some(0));
+}


### PR DESCRIPTION
And fix a panic. Arguable this should return a negative value but I've left the API the same for now.