### PR TITLE
Test with default features and minimal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  RUSTFLAGS: "-D warnings"
+
+jobs:
+
+  # test without default features
+  bdk-chain-test-minimal:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: "x86_64-unknown-linux-gnu"
+          override: true
+      - uses: Swatinem/rust-cache@v2.0.0
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release --no-default-features -p bdk_chain
+
+
+  # test without default features
+  bdk-chain-test-default:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: "x86_64-unknown-linux-gnu"
+          override: true
+      - uses: Swatinem/rust-cache@v2.0.0
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --release -p bdk_chain

--- a/bdk_chain/Cargo.toml
+++ b/bdk_chain/Cargo.toml
@@ -14,10 +14,10 @@ miniscript = { version = "9.0.0", optional = true  }
 bincode = { version = "2.0.0-rc.2", optional = true }
 
 [dev-dependencies]
-rand = "0.8.5"
+rand = "0.8"
 
 [features]
-default = ["std"]
+default = ["std", "miniscript"]
 std = []
 serde = ["serde_crate", "bitcoin/serde", "bincode/serde"]
 file_store = ["std", "bincode", "serde", "miniscript"]

--- a/bdk_chain/tests/test_keychain_tracker.rs
+++ b/bdk_chain/tests/test_keychain_tracker.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "miniscript")]
 use bdk_chain::{
     keychain::KeychainTracker,
     miniscript::{

--- a/bdk_chain/tests/test_keychain_txout_index.rs
+++ b/bdk_chain/tests/test_keychain_txout_index.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "miniscript")]
 use bdk_chain::collections::BTreeMap;
 
 use bdk_chain::keychain::KeychainTxOutIndex;


### PR DESCRIPTION
code coverage tests don't do this.

In practice the tests were failing unless --all-features was passed. 