### PR TITLE
Apply conflict rules in ChainGraph::apply_changeset

### DIFF
--- a/bdk_chain/src/keychain/keychain_tracker.rs
+++ b/bdk_chain/src/keychain/keychain_tracker.rs
@@ -1,4 +1,4 @@
-use bitcoin::{Transaction, Txid};
+use bitcoin::Transaction;
 use miniscript::{Descriptor, DescriptorPublicKey};
 
 use crate::{
@@ -83,22 +83,11 @@ where
     pub fn apply_changeset(
         &mut self,
         changeset: KeychainChangeSet<K, P>,
-    ) -> Result<(), (KeychainChangeSet<K, P>, HashSet<Txid>)> {
+    ) -> Result<(), chain_graph::InflateError<P>> {
         self.txout_index
             .store_all_up_to(&changeset.derivation_indices);
         self.txout_index.scan(&changeset);
-        let derivation_indices = changeset.derivation_indices;
-        self.chain_graph
-            .apply_changeset(changeset.chain_graph)
-            .map_err(|(cg_changeset, missing)| {
-                (
-                    KeychainChangeSet {
-                        derivation_indices,
-                        chain_graph: cg_changeset,
-                    },
-                    missing,
-                )
-            })
+        self.chain_graph.apply_changeset(changeset.chain_graph)
     }
 
     pub fn full_txouts(&self) -> impl Iterator<Item = (&(K, u32), FullTxOut<P>)> + '_ {

--- a/bdk_chain/src/sparse_chain.rs
+++ b/bdk_chain/src/sparse_chain.rs
@@ -555,7 +555,7 @@ impl<P: ChainPosition> SparseChain<P> {
     pub fn full_txout(&self, graph: &TxGraph, outpoint: OutPoint) -> Option<FullTxOut<P>> {
         let chain_pos = self.tx_position(outpoint.txid)?;
 
-        let txout = graph.txout(outpoint).cloned()?;
+        let txout = graph.get_txout(outpoint).cloned()?;
 
         let spent_by = self
             .spent_by(graph, outpoint)

--- a/bdk_chain/tests/test_chain_graph.rs
+++ b/bdk_chain/tests/test_chain_graph.rs
@@ -331,7 +331,21 @@ fn chain_graph_inflate_changeset() {
     expected_missing.remove(&tx_b.txid());
     assert_eq!(
         cg.inflate_changeset(chain_changeset.clone(), vec![tx_b.clone()]),
-        Err(InflateFailure::Missing(expected_missing))
+        Err(InflateFailure::Missing(expected_missing.clone()))
+    );
+
+    let _ = cg.insert_txout(
+        OutPoint {
+            txid: tx_a.txid(),
+            vout: 0,
+        },
+        tx_a.output[0].clone(),
+    );
+
+    assert_eq!(
+        cg.inflate_changeset(chain_changeset.clone(), vec![tx_b.clone()]),
+        Err(InflateFailure::Missing(expected_missing)),
+        "inserting an output instead of full tx doesn't satisfy constraint"
     );
 
     let mut additions = tx_graph::Additions::default();

--- a/bdk_chain/tests/test_chain_graph.rs
+++ b/bdk_chain/tests/test_chain_graph.rs
@@ -2,7 +2,7 @@
 mod common;
 
 use bdk_chain::{
-    chain_graph::{ChainGraph, ChangeSet, InflateFailure, UnresolvableConflict, UpdateFailure},
+    chain_graph::{ChainGraph, ChangeSet, InflateError, UnresolvableConflict, UpdateFailure},
     collections::HashSet,
     sparse_chain,
     tx_graph::{self, Additions},
@@ -250,7 +250,7 @@ fn update_missing_full_tx_errors() {
     expected.insert(h!("a2"));
     assert_eq!(
         cg.apply_changeset(changeset.clone()),
-        Err((changeset, expected))
+        Err(InflateError::Missing(expected))
     );
 }
 
@@ -325,13 +325,13 @@ fn chain_graph_inflate_changeset() {
 
     assert_eq!(
         cg.inflate_changeset(chain_changeset.clone(), vec![]),
-        Err(InflateFailure::Missing(expected_missing.clone()))
+        Err(InflateError::Missing(expected_missing.clone()))
     );
 
     expected_missing.remove(&tx_b.txid());
     assert_eq!(
         cg.inflate_changeset(chain_changeset.clone(), vec![tx_b.clone()]),
-        Err(InflateFailure::Missing(expected_missing.clone()))
+        Err(InflateError::Missing(expected_missing.clone()))
     );
 
     let _ = cg.insert_txout(
@@ -344,7 +344,7 @@ fn chain_graph_inflate_changeset() {
 
     assert_eq!(
         cg.inflate_changeset(chain_changeset.clone(), vec![tx_b.clone()]),
-        Err(InflateFailure::Missing(expected_missing)),
+        Err(InflateError::Missing(expected_missing)),
         "inserting an output instead of full tx doesn't satisfy constraint"
     );
 


### PR DESCRIPTION
commits:
1. Add test for bug I found where `ChainGraph` would be OK with the `TxGraph` only having txout for the chain transaction rather than a full transaction.
2. Removes error case from TxGraph's API. See #132 
3. Checks for conflicts in ChainGraph::apply_changeset

Note: we currently check for conflicts in the changeset with the chain graph's own state but not within the changeset itself which can lead to an inconsistent ChainGraph (conflicting txs).


Fixes #132 