### PR TITLE
Fix methods that iter scripts in `KeychainTxOutIndex`

### DIFF
--- a/bdk_chain/src/lib.rs
+++ b/bdk_chain/src/lib.rs
@@ -42,16 +42,14 @@ pub mod collections {
     #![allow(dead_code)]
     pub type HashSet<K> = alloc::collections::BTreeSet<K>;
     pub type HashMap<K, V> = alloc::collections::BTreeMap<K, V>;
-    pub use alloc::collections::btree_map as hash_map;
-    pub use alloc::collections::*;
+    pub use alloc::collections::{btree_map as hash_map, *};
 }
 
 // When we have std use `std`'s all collections
 #[cfg(all(feature = "std", not(feature = "hashbrown")))]
 #[doc(hidden)]
 pub mod collections {
-    pub use std::collections::hash_map;
-    pub use std::collections::*;
+    pub use std::collections::{hash_map, *};
 }
 
 // With special feature `hashbrown` use `hashbrown`'s hash collections, and else from `alloc`.

--- a/bdk_cli_lib/src/lib.rs
+++ b/bdk_cli_lib/src/lib.rs
@@ -206,7 +206,7 @@ where
                 true => Keychain::Internal,
                 false => Keychain::External,
             };
-            for (index, spk) in txout_index.script_pubkeys_of_keychain(&target_keychain) {
+            for (index, spk) in txout_index.stored_scripts_of_keychain(&target_keychain) {
                 let address = Address::from_script(&spk, network)
                     .expect("should always be able to derive address");
                 println!(

--- a/bdk_electrum_example/src/main.rs
+++ b/bdk_electrum_example/src/main.rs
@@ -83,7 +83,7 @@ fn main() -> anyhow::Result<()> {
         } => {
             let scripts = tracker
                 .txout_index
-                .script_pubkeys_of_all_keychains()
+                .scripts_of_all_keychains()
                 .into_iter()
                 .map(|(keychain, iter)| {
                     let mut first = true;

--- a/bdk_esplora_example/src/main.rs
+++ b/bdk_esplora_example/src/main.rs
@@ -61,7 +61,7 @@ fn main() -> anyhow::Result<()> {
         EsploraCommands::Scan { stop_gap } => {
             let spk_iterators = keychain_tracker
                 .txout_index
-                .script_pubkeys_of_all_keychains()
+                .scripts_of_all_keychains()
                 .into_iter()
                 .map(|(keychain, iter)| {
                     let mut first = true;


### PR DESCRIPTION
Fixes #136 

Now the methods are consistently named with consistent behavior.