### PR TITLE
`TxGraph` descendants

### DIFF
--- a/bdk_chain/src/tx_graph.rs
+++ b/bdk_chain/src/tx_graph.rs
@@ -1,11 +1,17 @@
+use core::ops::RangeInclusive;
+
 use crate::{collections::*, ForEachTxout};
-use alloc::{borrow::Cow, vec::Vec};
-use bitcoin::{OutPoint, Transaction, TxIn, TxOut, Txid};
+use alloc::vec::Vec;
+use bitcoin::{OutPoint, Transaction, TxOut, Txid};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct TxGraph {
     txs: HashMap<Txid, TxNode>,
     spends: BTreeMap<OutPoint, HashSet<Txid>>,
+
+    // This atrocity exists so that `TxGraph::outspends()` can return a reference.
+    // FIXME: This can be removed once `HashSet::new` is a const fn.
+    empty_outspends: HashSet<Txid>,
 }
 
 /// Node of a [`TxGraph`]
@@ -21,29 +27,13 @@ impl Default for TxNode {
     }
 }
 
-/// Do not filter any descendants.
-///
-/// This is a convenience method intended for use with [`TxGraph::iter_tx_descendants()`] and
-/// related methods.
-pub fn no_filter(_: usize, _: Txid) -> bool {
-    true
-}
-
 impl TxGraph {
     /// The transactions spending from this output.
     ///
     /// `TxGraph` allows conflicting transactions within the graph. Obviously the transactions in
     /// the returned will never be in the same blockchain.
-    ///
-    /// Note this returns a [`Cow`] because of an implementation detail.
-    ///
-    /// [`Cow`]: std::borrow::Cow
-    // FIXME: this Cow could be gotten rid of if we could do HashSet::new in a const fn
-    pub fn outspends(&self, outpoint: OutPoint) -> Cow<HashSet<Txid>> {
-        self.spends
-            .get(&outpoint)
-            .map(|outspends| Cow::Borrowed(outspends))
-            .unwrap_or(Cow::Owned(HashSet::default()))
+    pub fn outspends(&self, outpoint: OutPoint) -> &HashSet<Txid> {
+        self.spends.get(&outpoint).unwrap_or(&self.empty_outspends)
     }
 
     /// The transactions spending from `txid`.
@@ -191,68 +181,52 @@ impl TxGraph {
         })
     }
 
-    /// Iterates descendant transactions of given `txid` (including the given `txid`).
+    /// Creates an iterator that both filters and maps descendants from the starting `txid`.
     ///
-    /// if `path_filter` returns `true`, we will continue exploring the path from the `txid` of
-    /// `depth`, where `depth: usize` is the distance from the initial `txid` to the descendant.
-    pub fn iter_tx_descendants<'g>(
-        &'g self,
-        txid: Txid,
-        path_filter: impl FnMut(usize, Txid) -> bool + 'g,
-    ) -> impl Iterator<Item = (usize, Txid)> + '_ {
-        TxDescendants::new(self, txid, path_filter)
+    /// The supplied closure takes in two inputs `(depth, descendant_txid)`:
+    ///
+    /// * `depth` is the distance between the starting `txid` and the `descendant_txid`. I.e. if the
+    ///     descendant is spending an output of the starting `txid`, the `depth` will be 1.
+    /// * `descendant_txid` is the descendant's txid which we are considering to walk.
+    ///
+    /// The supplied closure returns an `Option<T>`, allowing the caller to map each node it vists
+    /// and decide whether to visit descendants.
+    pub fn walk_descendants<'g, F, T>(&'g self, txid: Txid, walk_map: F) -> TxDescendants<F>
+    where
+        F: FnMut(usize, Txid) -> Option<T> + 'g,
+    {
+        TxDescendants::new_exclude_root(self, txid, walk_map)
     }
 
-    /// Iterates over all conflicting txids (including descendants) of the given transaction.
+    /// Creates an iterator that both filters and maps conflicting transactions (this includes
+    /// descendants of directly-conflicting transactions, which are also considered conflicts).
     ///
-    /// The `path_filter` filters descendant paths to check. Refer to
-    /// [`Self::iter_tx_descendants()`] for more details.
-    pub fn tx_conflicts<'g>(
-        &'g self,
-        tx: &'g Transaction,
-        path_filter: impl Fn(usize, Txid) -> bool + 'g,
-    ) -> impl Iterator<Item = (usize, Txid)> + '_ {
-        self.adjacent_conflicts_of_tx(tx)
-            .flat_map(move |(_, txid)| {
-                self.iter_tx_descendants(txid, &path_filter)
-                    .collect::<Vec<_>>()
-            })
-    }
-
-    /// Given a `txin` and the `txid` of the transaction in which it resides, return an iterator of
-    /// txids which directly conflict with the given `txin`.
-    ///
-    /// **WARNING:** It is up to the caller to ensure the given `txin` actually resides in `txid`.
-    /// **WARNING:** This only returns directly conflicting txids and does not include descendants
-    /// of those txids.
-    pub fn adjacent_conflicts_of_txin<'g>(
-        &'g self,
-        txid: Txid,
-        txin: &'g TxIn,
-    ) -> impl Iterator<Item = Txid> + '_ {
-        self.spends
-            .get(&txin.previous_output)
-            .into_iter()
-            .flatten()
-            .filter(move |&&conflicting_txid| conflicting_txid != txid)
-            .cloned()
+    /// Refer to [`Self::walk_descendants()`] for `walk_map` usage.
+    pub fn walk_conflicts<'g, F, T>(&'g self, tx: &'g Transaction, walk_map: F) -> TxDescendants<F>
+    where
+        F: FnMut(usize, Txid) -> Option<T> + 'g,
+    {
+        let txids = self.direct_conflicts_of_tx(tx).map(|(_, txid)| txid);
+        TxDescendants::from_multiple_include_root(self, txids, walk_map)
     }
 
     /// Given a transaction, return an iterator of txids which directly conflict with the given
     /// transaction's inputs (spends). The conflicting txids are returned with the given
     /// transaction's vin (in which it conflicts).
     ///
-    /// **WARNING:** This only returns directly conflicting txids and does not include descendants
-    /// of those txids.
-    pub fn adjacent_conflicts_of_tx<'g>(
+    /// Note that this only returns directly conflicting txids and does not include descendants of
+    /// those txids (which are technically also conflicting).
+    pub fn direct_conflicts_of_tx<'g>(
         &'g self,
         tx: &'g Transaction,
     ) -> impl Iterator<Item = (usize, Txid)> + '_ {
         let txid = tx.txid();
-        tx.input.iter().enumerate().flat_map(move |(vin, txin)| {
-            self.adjacent_conflicts_of_txin(txid, txin)
-                .map(move |txid| (vin, txid))
-        })
+        tx.input
+            .iter()
+            .enumerate()
+            .filter_map(|(vin, txin)| self.spends.get(&txin.previous_output).zip(Some(vin)))
+            .flat_map(|(spends, vin)| core::iter::repeat(vin).zip(spends.iter().cloned()))
+            .filter(move |(_, conflicting_txid)| *conflicting_txid != txid)
     }
 
     /// Previews the resultant [`Additions`] when [`Self`] is updated against the `update` graph.
@@ -403,51 +377,107 @@ impl ForEachTxout for Additions {
     }
 }
 
-pub struct TxDescendants<'a, F> {
-    graph: &'a TxGraph,
-    path_filter: F,
+pub struct TxDescendants<'g, F> {
+    graph: &'g TxGraph,
     visited: HashSet<Txid>,
     stack: Vec<(usize, Txid)>,
+    filter_map: F,
 }
 
-impl<'a, F> TxDescendants<'a, F> {
-    fn new(graph: &'a TxGraph, txid: Txid, path_filter: F) -> Self {
+impl<'g, F> TxDescendants<'g, F> {
+    /// Creates a `TxDescendants` that includes the starting `txid` when iterating.
+    #[allow(unused)]
+    pub(crate) fn new_include_root(graph: &'g TxGraph, txid: Txid, filter_map: F) -> Self {
         Self {
             graph,
-            path_filter,
-            visited: [].into(),
+            visited: Default::default(),
             stack: [(0, txid)].into(),
+            filter_map,
         }
+    }
+
+    /// Creates a `TxDescendants` that excludes the starting `txid` when iterating.
+    pub(crate) fn new_exclude_root(graph: &'g TxGraph, txid: Txid, filter_map: F) -> Self {
+        let mut descendants = Self {
+            graph,
+            visited: Default::default(),
+            stack: Default::default(),
+            filter_map,
+        };
+        descendants.populate_stack(1, txid);
+        descendants
+    }
+
+    /// Creates a `TxDescendants` from multiple starting transactions that includes the starting
+    /// `txid`s when iterating.
+    pub(crate) fn from_multiple_include_root<I>(graph: &'g TxGraph, txids: I, filter_map: F) -> Self
+    where
+        I: IntoIterator<Item = Txid>,
+    {
+        Self {
+            graph,
+            visited: Default::default(),
+            stack: txids.into_iter().map(|txid| (0, txid)).collect(),
+            filter_map,
+        }
+    }
+
+    /// Creates a `TxDescendants` from multiple starting transactions that excludes the starting
+    /// `txid`s when iterating.
+    #[allow(unused)]
+    pub(crate) fn from_multiple_exclude_root<I>(graph: &'g TxGraph, txids: I, filter_map: F) -> Self
+    where
+        I: IntoIterator<Item = Txid>,
+    {
+        let mut descendants = Self {
+            graph,
+            visited: Default::default(),
+            stack: Default::default(),
+            filter_map,
+        };
+        for txid in txids {
+            descendants.populate_stack(1, txid);
+        }
+        descendants
     }
 }
 
-impl<'a, F> Iterator for TxDescendants<'a, F>
+impl<'g, F> TxDescendants<'g, F> {
+    fn populate_stack(&mut self, depth: usize, txid: Txid) {
+        let spend_paths = self
+            .graph
+            .spends
+            .range(tx_outpoint_range(txid))
+            .flat_map(|(_, spends)| spends)
+            .map(|&txid| (depth, txid));
+        self.stack.extend(spend_paths);
+    }
+}
+
+impl<'g, F, T> Iterator for TxDescendants<'g, F>
 where
-    F: FnMut(usize, Txid) -> bool,
+    F: FnMut(usize, Txid) -> Option<T>,
 {
-    type Item = (usize, Txid);
+    type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let (depth, txid) = self.stack.pop()?;
-            if !self.visited.insert(txid) {
-                continue;
+        let (op_spends, txid, item) = loop {
+            // we have exhausted all paths when stack is empty
+            let (op_spends, txid) = self.stack.pop()?;
+            // we do not want to visit the same transaction twice
+            if self.visited.insert(txid) {
+                // ignore paths when user filters them out
+                if let Some(item) = (self.filter_map)(op_spends, txid) {
+                    break (op_spends, txid, item);
+                }
             }
-            if (self.path_filter)(depth, txid) {
-                let mut children = self
-                    .graph
-                    .spends
-                    .range(OutPoint::new(txid, u32::MIN)..=OutPoint::new(txid, u32::MAX))
-                    .flat_map(|(_, txids)| txids)
-                    .map(|&txid| (depth + 1, txid))
-                    .collect::<Vec<_>>();
-                self.stack.append(&mut children);
-                return Some((depth, txid));
-            }
-        }
-    }
+        };
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.stack.len(), None)
+        self.populate_stack(op_spends + 1, txid);
+        return Some(item);
     }
+}
+
+fn tx_outpoint_range(txid: Txid) -> RangeInclusive<OutPoint> {
+    OutPoint::new(txid, u32::MIN)..=OutPoint::new(txid, u32::MAX)
 }

--- a/bdk_chain/tests/common/mod.rs
+++ b/bdk_chain/tests/common/mod.rs
@@ -48,3 +48,13 @@ macro_rules! changeset {
         }
     }};
 }
+
+#[allow(unused)]
+pub fn new_tx(lt: u32) -> bitcoin::Transaction {
+    bitcoin::Transaction {
+        version: 0x00,
+        lock_time: bitcoin::PackedLockTime(lt),
+        input: vec![],
+        output: vec![],
+    }
+}


### PR DESCRIPTION
This PR currently implements:
* Evicting descendants of conflicting transactions (before, we only evicted direct conflicts). -- #120
* The evict-descendant logic is now used to fix: #139
* Traversing descendants of given `Txid`.