### PR TITLE
Improve file store ergonomics

### DIFF
--- a/bdk_chain/src/file_store.rs
+++ b/bdk_chain/src/file_store.rs
@@ -3,18 +3,18 @@ use crate::{
     keychain::{KeychainChangeSet, KeychainTracker},
     sparse_chain,
 };
+use core::marker::PhantomData;
 use std::{
     fs::{File, OpenOptions},
     io::{self, Seek},
     path::Path,
 };
 
-/// Persists changes made to a [`KeychainTracker`] to a file so they can be restored later on.
+/// Persists an append only list of `KeychainChangeSet<K,P>` to a single file.
+/// [`KeychainChangeSet<K,P>`] record the changes made to a [`KeychainTracker<K,P>`].
 #[derive(Debug)]
 pub struct KeychainStore<K, P> {
     db_file: File,
-    /// A cache of what the current state of the derivation indexes are on-disk
-    deriviation_index_cache: BTreeMap<K, u32>,
     chain_index: core::marker::PhantomData<(K, P)>,
 }
 
@@ -24,52 +24,85 @@ where
     P: sparse_chain::ChainPosition,
     KeychainChangeSet<K, P>: serde::Serialize + serde::de::DeserializeOwned,
 {
-    pub fn load(db_path: &Path, tracker: &mut KeychainTracker<K, P>) -> Result<Self, io::Error> {
-        let mut db_file = OpenOptions::new()
+    /// Creates a new store from a [`File`].
+    ///
+    /// The file must have been opened with read, write permissions.
+    ///
+    /// [`File`]: std::fs::File
+    pub fn new(file: File) -> Self {
+        Self {
+            db_file: file,
+            chain_index: Default::default(),
+        }
+    }
+
+    /// Creates or loads a a store from `db_path`. If no file exists there it will be created.
+    pub fn new_from_path(db_path: &Path) -> Result<Self, io::Error> {
+        let db_file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .open(db_path.clone())?;
 
-        loop {
-            let pos = db_file.stream_position()?;
-
-            let failed =
-                match bincode::decode_from_std_read(&mut db_file, bincode::config::standard()) {
-                    Ok(bincode::serde::Compat(changeset @ KeychainChangeSet::<K, P> { .. })) => {
-                        tracker
-                            .txout_index
-                            .store_all_up_to(&changeset.derivation_indices);
-                        tracker.apply_changeset(changeset).is_err()
-                    }
-                    Err(e) => {
-                        if let bincode::error::DecodeError::Io { inner, .. } = e {
-                            // The only kind of error that we actually want to return are read failures
-                            // caused by device failure etc. UnexpectedEof just menas that whatever was
-                            // left after the last entry wasn't enough to be decoded (usually its 0
-                            // bytes) -- If it's not empty we can just ignore it and write over the
-                            // corrupted entry.
-                            if inner.kind() != io::ErrorKind::UnexpectedEof {
-                                return Err(inner);
-                            }
-                        }
-                        true
-                    }
-                };
-
-            if failed {
-                db_file.seek(io::SeekFrom::Start(pos))?;
-                break;
-            }
-        }
-
-        Ok(Self {
-            deriviation_index_cache: tracker.txout_index.derivation_indices(),
-            db_file,
-            chain_index: Default::default(),
-        })
+        Ok(Self::new(db_file))
     }
 
+    /// Iterates over the stored changeset from first to last changing the seek position at each
+    /// iteration.
+    ///
+    /// The iterator may fail to read an entry and therefore return an error. However the first time
+    /// it returns an error will be the last. After doing so the iterator will always yield `None`.
+    ///
+    /// **WARNING**: This method changes the write position in the underlying file. You should
+    /// always iterate over all entries until `None` is returned if you want your next write to go
+    /// at the end, otherwise you writing over existing enties.
+    pub fn iter_changesets(&mut self) -> Result<EntryIter<'_, KeychainChangeSet<K, P>>, io::Error> {
+        self.db_file.rewind()?;
+
+        Ok(EntryIter::new(&mut self.db_file))
+    }
+
+    /// Loads all the changesets that have been stored as one giant changeset.
+    ///
+    /// This function returns a tuple of the aggregate changeset and a result which indicates
+    /// whether an error occurred while reading or deserializing one of the entries. If so the
+    /// changeset will consist of all of those it was able to read.
+    ///
+    /// You should usually check the error. In many applications it may make sense to do a full
+    /// wallet scan with a stop gap after getting an error since it is likely that one of the
+    /// changesets it was unable to read changed the derivation indicies of the tracker.
+    ///
+    /// **WARNING**: This method changes the write position of the underlying file. The next
+    /// changeset will be written over the erroring entry (or the end of the file if none existed).
+    pub fn aggregate_changeset(&mut self) -> (KeychainChangeSet<K, P>, Result<(), IterError>) {
+        let mut changeset = KeychainChangeSet::default();
+        let result = (|| {
+            let iter_changeset = self.iter_changesets()?;
+            for next_changeset in iter_changeset {
+                changeset.append(next_changeset?);
+            }
+            Ok(())
+        })();
+
+        (changeset, result)
+    }
+
+    /// Reads and applies all the changesets stored sequentially to tracker, stopping when it fails
+    /// to read the next one.
+    ///
+    /// **WARNING**: This method changes the write position of the underlying file. The next
+    /// changeset will be written over the erroring entry (or the end of the file if none existed).
+    pub fn load_into_keychain_tracker(
+        &mut self,
+        tracker: &mut KeychainTracker<K, P>,
+    ) -> Result<(), IterError> {
+        for changeset in self.iter_changesets()? {
+            tracker.apply_changeset(changeset?)
+        }
+        Ok(())
+    }
+
+    /// Append a new changeset to the file.
     pub fn append_changeset(
         &mut self,
         changeset: &KeychainChangeSet<K, P>,
@@ -88,26 +121,104 @@ where
             // We want to make sure that derivation indexe changes are written to disk as soon as
             // possible so you know about the write failure before you give ou the address in the application.
             if !changeset.derivation_indices.is_empty() {
-                self.db_file.sync_data()?
+                self.db_file.sync_data()?;
             }
         }
 
         Ok(())
     }
 
+    /// Appends a new changeset setting the derivation indicies
     pub fn set_derivation_indices(&mut self, indices: BTreeMap<K, u32>) -> Result<(), io::Error> {
         let keychain_changeset = KeychainChangeSet {
             chain_graph: Default::default(),
-            derivation_indices: indices
-                .into_iter()
-                .filter(|(keychain, index)| {
-                    self.deriviation_index_cache.get(keychain) != Some(index)
-                })
-                .collect(),
+            derivation_indices: indices,
         };
-
         self.append_changeset(&keychain_changeset)?;
 
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum IterError {
+    Io(io::Error),
+    Bincode(bincode::error::DecodeError),
+}
+
+impl core::fmt::Display for IterError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            IterError::Io(e) => write!(f, "io error trying to read entry {}", e),
+            IterError::Bincode(e) => write!(f, "bincode error while reading entry {}", e),
+        }
+    }
+}
+
+impl std::error::Error for IterError {}
+
+/// Iterator over entries in a file store.
+///
+/// Reads and returns an entry each time [`next`] is called. If an error occurs while reading the
+/// iterator will yield a `Result::Err(_)` instead and then `None` for the next call to `next`.
+///
+/// [`next`]: Self::next
+pub struct EntryIter<'a, V> {
+    db_file: &'a mut File,
+    types: PhantomData<V>,
+    error_exit: bool,
+}
+
+impl<'a, V> EntryIter<'a, V> {
+    pub fn new(db_file: &'a mut File) -> Self {
+        Self {
+            db_file,
+            types: PhantomData,
+            error_exit: false,
+        }
+    }
+}
+
+impl<'a, V> Iterator for EntryIter<'a, V>
+where
+    V: serde::de::DeserializeOwned,
+{
+    type Item = Result<V, IterError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let result = (|| {
+            let pos = self.db_file.stream_position()?;
+
+            match bincode::decode_from_std_read(self.db_file, bincode::config::standard()) {
+                Ok(bincode::serde::Compat(changeset)) => Ok(Some(changeset)),
+                Err(e) => {
+                    if let bincode::error::DecodeError::Io { inner, .. } = &e {
+                        if inner.kind() == io::ErrorKind::UnexpectedEof {
+                            let eof = self.db_file.seek(io::SeekFrom::End(0))?;
+                            if pos == eof {
+                                return Ok(None);
+                            }
+                        }
+                    }
+
+                    self.db_file.seek(io::SeekFrom::Start(pos))?;
+                    Err(IterError::Bincode(e))
+                }
+            }
+        })();
+
+        let result = result.transpose();
+
+        if let Some(Err(_)) = &result {
+            self.error_exit = true;
+        }
+
+        result
+    }
+}
+
+impl From<io::Error> for IterError {
+    fn from(value: io::Error) -> Self {
+        IterError::Io(value)
     }
 }

--- a/bdk_chain/src/keychain/keychain_tracker.rs
+++ b/bdk_chain/src/keychain/keychain_tracker.rs
@@ -77,15 +77,11 @@ where
         scan: KeychainScan<K, P>,
     ) -> Result<KeychainChangeSet<K, P>, chain_graph::UpdateError<P>> {
         let changeset = self.determine_changeset(&scan)?;
-        self.apply_changeset(changeset.clone())
-            .expect("generated changeset should apply");
+        self.apply_changeset(changeset.clone());
         Ok(changeset)
     }
 
-    pub fn apply_changeset(
-        &mut self,
-        changeset: KeychainChangeSet<K, P>,
-    ) -> Result<(), chain_graph::InflateError<P>> {
+    pub fn apply_changeset(&mut self, changeset: KeychainChangeSet<K, P>) {
         self.txout_index
             .store_all_up_to(&changeset.derivation_indices);
         self.txout_index.scan(&changeset);
@@ -137,8 +133,7 @@ where
         block_id: BlockId,
     ) -> Result<KeychainChangeSet<K, P>, chain_graph::InsertCheckpointError> {
         let changeset = self.insert_checkpoint_preview(block_id)?;
-        self.apply_changeset(changeset.clone())
-            .expect("changeset should apply");
+        self.apply_changeset(changeset.clone());
         Ok(changeset)
     }
 
@@ -164,8 +159,7 @@ where
         pos: P,
     ) -> Result<KeychainChangeSet<K, P>, chain_graph::InsertTxError<P>> {
         let changeset = self.insert_tx_preview(tx, pos)?;
-        self.apply_changeset(changeset.clone())
-            .expect("changeset should apply");
+        self.apply_changeset(changeset.clone());
         Ok(changeset)
     }
 

--- a/bdk_chain/src/tx_graph.rs
+++ b/bdk_chain/src/tx_graph.rs
@@ -276,6 +276,11 @@ impl TxGraph {
             }
         }
     }
+
+    /// Whether the graph has any transactions or outputs in it.
+    pub fn is_empty(&self) -> bool {
+        self.txs.is_empty()
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -316,6 +321,13 @@ impl Additions {
                     .map(|(vout, txout)| (OutPoint::new(tx.txid(), vout as _), txout))
             })
             .chain(self.txout.iter().map(|(op, txout)| (*op, txout)))
+    }
+
+    /// Appends the changes in `other` into self such that applying `self` afterwards has the same
+    /// effect as sequentially applying the original `self` and `other`.
+    pub fn append(&mut self, mut other: Additions) {
+        self.tx.append(&mut other.tx);
+        self.txout.append(&mut other.txout);
     }
 }
 

--- a/bdk_chain/tests/test_chain_graph.rs
+++ b/bdk_chain/tests/test_chain_graph.rs
@@ -8,9 +8,7 @@ use bdk_chain::{
     tx_graph::{self, Additions},
     BlockId, TxHeight,
 };
-use bitcoin::{
-    OutPoint, PackedLockTime, Script, Sequence, Transaction, TxIn, TxOut, Txid, Witness,
-};
+use bitcoin::{OutPoint, PackedLockTime, Script, Sequence, Transaction, TxIn, TxOut, Witness};
 
 #[test]
 fn test_spent_by() {
@@ -146,7 +144,7 @@ fn update_evicts_conflicting_tx() {
             "tx should be evicted from mempool"
         );
 
-        cg1.apply_changeset(changeset).expect("should apply");
+        cg1.apply_changeset(changeset);
     }
 
     {
@@ -225,74 +223,8 @@ fn update_evicts_conflicting_tx() {
             "tx should be evicted from B",
         );
 
-        cg1.apply_changeset(changeset).expect("should apply");
+        cg1.apply_changeset(changeset);
     }
-}
-
-#[test]
-fn update_missing_full_tx_errors() {
-    let mut cg = ChainGraph::default();
-    let chain_changeset = changeset! {
-        checkpoints: [
-            (0, Some(h!("A")))
-        ],
-        txids: [
-            (h!("a1"), Some(TxHeight::Confirmed(0))),
-            (h!("a2"), Some(TxHeight::Unconfirmed))
-        ]
-    };
-    let changeset = ChangeSet {
-        chain: chain_changeset,
-        graph: tx_graph::Additions::default(),
-    };
-    let mut expected = HashSet::<Txid>::new();
-    expected.insert(h!("a1"));
-    expected.insert(h!("a2"));
-    assert_eq!(
-        cg.apply_changeset(changeset.clone()),
-        Err(InflateError::Missing(expected))
-    );
-}
-
-#[test]
-fn update_not_including_tx_already_in_graph_is_ok() {
-    let mut cg = ChainGraph::default();
-    let tx_a = Transaction {
-        version: 0x01,
-        lock_time: PackedLockTime(0),
-        input: vec![],
-        output: vec![TxOut::default()],
-    };
-    let chain_changeset = changeset! {
-        checkpoints: [ (0, Some(h!("A"))) ],
-        txids: [
-            (tx_a.txid(), Some(TxHeight::Confirmed(0)))
-        ]
-    };
-
-    let mut graph_additions = tx_graph::Additions::default();
-    graph_additions.tx.insert(tx_a.clone());
-    let changeset = ChangeSet {
-        chain: chain_changeset,
-        graph: graph_additions,
-    };
-
-    assert_eq!(cg.apply_changeset(changeset), Ok(()));
-
-    // reorg the tx to a different height and provide changeset without the full tx.
-    let chain_changeset = changeset! {
-        checkpoints: [(0, Some(h!("A'")))],
-        txids: [
-            (tx_a.txid(), Some(TxHeight::Unconfirmed))
-        ]
-    };
-
-    let changeset = ChangeSet {
-        chain: chain_changeset,
-        graph: tx_graph::Additions::default(),
-    };
-
-    assert_eq!(cg.apply_changeset(changeset), Ok(()));
 }
 
 #[test]
@@ -360,7 +292,7 @@ fn chain_graph_inflate_changeset() {
         })
     );
 
-    assert_eq!(cg.apply_changeset(changeset.unwrap()), Ok(()))
+    cg.apply_changeset(changeset.unwrap());
 }
 
 #[test]

--- a/bdk_chain/tests/test_keychain_tracker.rs
+++ b/bdk_chain/tests/test_keychain_tracker.rs
@@ -33,7 +33,7 @@ fn test_insert_tx() {
     let changeset = tracker
         .insert_tx_preview(tx.clone(), ConfirmationTime::Unconfirmed)
         .unwrap();
-    tracker.apply_changeset(changeset).unwrap();
+    tracker.apply_changeset(changeset);
     assert_eq!(
         tracker
             .chain_graph()

--- a/bdk_electrum_example/src/main.rs
+++ b/bdk_electrum_example/src/main.rs
@@ -183,8 +183,6 @@ fn main() -> anyhow::Result<()> {
     keychain_changeset.chain_graph = chaingraph_changeset;
 
     db.append_changeset(&keychain_changeset)?;
-    tracker
-        .apply_changeset(keychain_changeset)
-        .expect("cannot happen as tracker produced this changeset");
+    tracker.apply_changeset(keychain_changeset);
     Ok(())
 }

--- a/bdk_esplora_example/src/main.rs
+++ b/bdk_esplora_example/src/main.rs
@@ -141,10 +141,8 @@ fn main() -> anyhow::Result<()> {
                 .determine_changeset(&scan)?
                 .into();
             db.append_changeset(&changeset)?;
-            keychain_tracker
-                .apply_changeset(changeset)
-                .expect("it was just generated");
-        } // For everything else run handler
+            keychain_tracker.apply_changeset(changeset);
+        }
     }
 
     Ok(())


### PR DESCRIPTION
We need to be able to open a file without loading it yet.

Added is_empty methods on some types that I didn't end up using but kept them because it seemed helpful.

Removed the caching of derivation indices within the store because it wasn't really doing it's job with the cli example and we should do this properly on the outside.