### PR TITLE
test: Add case to cover unknown outpoint in `calculate_fee`

### DIFF
--- a/bdk_chain/tests/test_tx_graph.rs
+++ b/bdk_chain/tests/test_tx_graph.rs
@@ -338,6 +338,16 @@ fn test_calculate_fee() {
 
     // fee would be negative
     assert_eq!(graph.calculate_fee(&tx), Some(-200));
+
+    // If we have an unknown outpoint, fee should return None.
+    tx.input.push(TxIn {
+        previous_output: OutPoint {
+            txid: h!("unknown_txid"),
+            vout: 0,
+        },
+        ..Default::default()
+    });
+    assert_eq!(graph.calculate_fee(&tx), None);
 }
 
 #[test]


### PR DESCRIPTION
If we have an unknown transaction input, i.e an outpoint we don't have the `TxOut` for, `calculate_fee` should return `None`. 

Fixes #140 .