### PR TITLE
Truncate after `KeychainStore::append_changeset` and magic bytes

### DIFF
--- a/bdk_chain/src/file_store.rs
+++ b/bdk_chain/src/file_store.rs
@@ -124,7 +124,10 @@ where
         Ok(())
     }
 
-    /// Append a new changeset to the file.
+    /// Append a new changeset to the file and truncate file to the end of the appended changeset.
+    ///
+    /// The truncation is to avoid the possibility of having a valid, but inconsistent changeset
+    /// directly after the appended changeset.
     pub fn append_changeset(
         &mut self,
         changeset: &KeychainChangeSet<K, P>,

--- a/bdk_chain/src/file_store.rs
+++ b/bdk_chain/src/file_store.rs
@@ -6,9 +6,15 @@ use crate::{
 use core::marker::PhantomData;
 use std::{
     fs::{File, OpenOptions},
-    io::{self, Seek},
+    io::{self, Read, Seek, Write},
     path::Path,
 };
+
+/// BDK File Store magic bytes length.
+pub const MAGIC_BYTES_LEN: usize = 12;
+
+/// BDK File Store magic bytes.
+pub const MAGIC_BYTES: [u8; MAGIC_BYTES_LEN] = [98, 100, 107, 102, 115, 48, 48, 48, 48, 48, 48, 48];
 
 /// Persists an append only list of `KeychainChangeSet<K,P>` to a single file.
 /// [`KeychainChangeSet<K,P>`] record the changes made to a [`KeychainTracker<K,P>`].
@@ -29,22 +35,37 @@ where
     /// The file must have been opened with read, write permissions.
     ///
     /// [`File`]: std::fs::File
-    pub fn new(file: File) -> Self {
-        Self {
+    pub fn new(mut file: File) -> Result<Self, FileError> {
+        file.rewind()?;
+
+        let mut magic_bytes = [0_u8; MAGIC_BYTES_LEN];
+        file.read_exact(&mut magic_bytes)?;
+
+        if magic_bytes != MAGIC_BYTES {
+            return Err(FileError::InvalidMagicBytes(magic_bytes));
+        }
+
+        Ok(Self {
             db_file: file,
             chain_index: Default::default(),
-        }
+        })
     }
 
     /// Creates or loads a a store from `db_path`. If no file exists there it will be created.
-    pub fn new_from_path(db_path: &Path) -> Result<Self, io::Error> {
-        let db_file = OpenOptions::new()
+    pub fn new_from_path<D: AsRef<Path>>(db_path: D) -> Result<Self, FileError> {
+        let already_exists = db_path.as_ref().try_exists()?;
+
+        let mut db_file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
-            .open(db_path.clone())?;
+            .open(db_path)?;
 
-        Ok(Self::new(db_file))
+        if !already_exists {
+            db_file.write_all(&MAGIC_BYTES)?;
+        }
+
+        Self::new(db_file)
     }
 
     /// Iterates over the stored changeset from first to last changing the seek position at each
@@ -57,7 +78,8 @@ where
     /// always iterate over all entries until `None` is returned if you want your next write to go
     /// at the end, otherwise you writing over existing enties.
     pub fn iter_changesets(&mut self) -> Result<EntryIter<'_, KeychainChangeSet<K, P>>, io::Error> {
-        self.db_file.rewind()?;
+        self.db_file
+            .seek(io::SeekFrom::Start(MAGIC_BYTES_LEN as _))?;
 
         Ok(EntryIter::new(&mut self.db_file))
     }
@@ -107,22 +129,30 @@ where
         &mut self,
         changeset: &KeychainChangeSet<K, P>,
     ) -> Result<(), io::Error> {
-        if !changeset.is_empty() {
-            bincode::encode_into_std_write(
-                bincode::serde::Compat(changeset),
-                &mut self.db_file,
-                bincode::config::standard(),
-            )
-            .map_err(|e| match e {
-                bincode::error::EncodeError::Io { inner, .. } => inner,
-                unexpected_err => panic!("unexpected bincode error: {}", unexpected_err),
-            })?;
+        if changeset.is_empty() {
+            return Ok(());
+        }
 
-            // We want to make sure that derivation indexe changes are written to disk as soon as
-            // possible so you know about the write failure before you give ou the address in the application.
-            if !changeset.derivation_indices.is_empty() {
-                self.db_file.sync_data()?;
-            }
+        bincode::encode_into_std_write(
+            bincode::serde::Compat(changeset),
+            &mut self.db_file,
+            bincode::config::standard(),
+        )
+        .map_err(|e| match e {
+            bincode::error::EncodeError::Io { inner, .. } => inner,
+            unexpected_err => panic!("unexpected bincode error: {}", unexpected_err),
+        })?;
+
+        // truncate file after this changeset addition
+        // if this is not done, data after this changeset may represent valid changesets, however
+        // applying those changesets on top of this one may result in inconsistent state
+        let pos = self.db_file.stream_position()?;
+        self.db_file.set_len(pos)?;
+
+        // We want to make sure that derivation indexe changes are written to disk as soon as
+        // possible so you know about the write failure before you give ou the address in the application.
+        if !changeset.derivation_indices.is_empty() {
+            self.db_file.sync_data()?;
         }
 
         Ok(())
@@ -139,6 +169,35 @@ where
         Ok(())
     }
 }
+
+#[derive(Debug)]
+pub enum FileError {
+    /// IO error, this may mean that the file is too short.
+    Io(io::Error),
+    /// Magic bytes do not match expected.
+    InvalidMagicBytes([u8; MAGIC_BYTES_LEN]),
+}
+
+impl core::fmt::Display for FileError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "io error trying to read file: {}", e),
+            Self::InvalidMagicBytes(b) => write!(
+                f,
+                "file has invalid magic bytes: expected={:?} got={:?}",
+                MAGIC_BYTES, b
+            ),
+        }
+    }
+}
+
+impl From<io::Error> for FileError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}
+
+impl std::error::Error for FileError {}
 
 #[derive(Debug)]
 pub enum IterError {

--- a/bdk_chain/src/lib.rs
+++ b/bdk_chain/src/lib.rs
@@ -23,7 +23,7 @@ pub mod file_store;
 extern crate alloc;
 
 #[cfg(feature = "serde")]
-extern crate serde_crate as serde;
+pub extern crate serde_crate as serde;
 
 #[cfg(feature = "bincode")]
 extern crate bincode;

--- a/bdk_chain/tests/test_file_store.rs
+++ b/bdk_chain/tests/test_file_store.rs
@@ -1,0 +1,153 @@
+#![cfg(feature = "file_store")]
+
+use std::{
+    fs::{File, OpenOptions},
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+
+use bdk_chain::{
+    file_store::{FileError, IterError, KeychainStore, MAGIC_BYTES, MAGIC_BYTES_LEN},
+    keychain::KeychainChangeSet,
+    serde, TxHeight,
+};
+
+#[macro_use]
+mod common;
+
+struct TempPath(PathBuf);
+
+impl TempPath {
+    fn new() -> Self {
+        let now = std::time::UNIX_EPOCH
+            .elapsed()
+            .expect("must get epoch")
+            .as_nanos();
+        let mut file_path = std::env::temp_dir();
+        file_path.push(format!("bdk_test_{}", now));
+        Self(file_path)
+    }
+
+    fn open(&self) -> File {
+        OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(self.0.as_path())
+            .expect("must open")
+    }
+}
+
+impl AsRef<Path> for TempPath {
+    fn as_ref(&self) -> &Path {
+        self.0.as_path()
+    }
+}
+
+impl Drop for TempPath {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(self.0.as_path()) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                panic!("remove file unexpected error: {}", e);
+            }
+        };
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(crate = "serde_crate")
+)]
+enum TestKeychain {
+    External,
+    Internal,
+}
+
+impl core::fmt::Display for TestKeychain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::External => write!(f, "external"),
+            Self::Internal => write!(f, "internal"),
+        }
+    }
+}
+
+#[test]
+fn magic_bytes() {
+    assert_eq!(&MAGIC_BYTES, "bdkfs0000000".as_bytes());
+}
+
+#[test]
+fn new_fails_if_file_is_too_short() {
+    let path = TempPath::new();
+    path.open()
+        .write_all(&MAGIC_BYTES[..MAGIC_BYTES_LEN - 1])
+        .expect("should write");
+
+    match KeychainStore::<TestKeychain, TxHeight>::new(path.open()) {
+        Err(FileError::Io(e)) => assert_eq!(e.kind(), std::io::ErrorKind::UnexpectedEof),
+        unexpected => panic!("unexpected result: {:?}", unexpected),
+    };
+}
+
+#[test]
+fn new_fails_if_magic_bytes_are_invalid() {
+    let invalid_magic_mnemonic = "ldkfs0000000";
+
+    let path = TempPath::new();
+    path.open()
+        .write_all(invalid_magic_mnemonic.as_bytes())
+        .expect("should write");
+
+    match KeychainStore::<TestKeychain, TxHeight>::new(path.open()) {
+        Err(FileError::InvalidMagicBytes(b)) => assert_eq!(b, invalid_magic_mnemonic.as_bytes()),
+        unexpected => panic!("unexpected result: {:?}", unexpected),
+    };
+}
+
+#[test]
+fn append_changeset_truncates_invalid_bytes() {
+    // initial data to write to file (magic bytes + invalid data)
+    let mut data = [255_u8; 2000];
+    data[..MAGIC_BYTES_LEN].copy_from_slice(&MAGIC_BYTES);
+
+    // changeset to append (invalid bytes should be truncated after appending)
+    let changeset = KeychainChangeSet {
+        derivation_indices: [(TestKeychain::External, 21), (TestKeychain::Internal, 21)].into(),
+        chain_graph: Default::default(),
+    };
+
+    let path = TempPath::new();
+    path.open().write_all(&data).expect("should write");
+
+    let mut store = KeychainStore::<TestKeychain, TxHeight>::new(path.open()).expect("should open");
+    match store.iter_changesets().expect("seek should succeed").next() {
+        Some(Err(IterError::Bincode(_))) => {}
+        unexpected_res => panic!("unexpected result: {:?}", unexpected_res),
+    }
+
+    store.append_changeset(&changeset).expect("should append");
+
+    drop(store);
+
+    let got_bytes = {
+        let mut buf = Vec::new();
+        path.open().read_to_end(&mut buf).expect("should read");
+        buf
+    };
+
+    let expected_bytes = {
+        let mut buf = MAGIC_BYTES.to_vec();
+        bincode::encode_into_std_write(
+            bincode::serde::Compat(&changeset),
+            &mut buf,
+            bincode::config::standard(),
+        )
+        .expect("should encode");
+        buf
+    };
+
+    assert_eq!(got_bytes, expected_bytes);
+}


### PR DESCRIPTION
Without truncating after appending a changeset, we may result in a sequence of changesets that loads an inconsistent tracker.

Magic bytes are introduced to avoid accidentally truncating non-bdk_file_store files.