### PR TITLE
Methods that change derivation indicies should return changesets

### DIFF
--- a/bdk_chain/src/file_store.rs
+++ b/bdk_chain/src/file_store.rs
@@ -1,5 +1,4 @@
 use crate::{
-    collections::BTreeMap,
     keychain::{KeychainChangeSet, KeychainTracker},
     sparse_chain,
 };
@@ -124,17 +123,6 @@ where
                 self.db_file.sync_data()?;
             }
         }
-
-        Ok(())
-    }
-
-    /// Appends a new changeset setting the derivation indicies
-    pub fn set_derivation_indices(&mut self, indices: BTreeMap<K, u32>) -> Result<(), io::Error> {
-        let keychain_changeset = KeychainChangeSet {
-            chain_graph: Default::default(),
-            derivation_indices: indices.into(),
-        };
-        self.append_changeset(&keychain_changeset)?;
 
         Ok(())
     }

--- a/bdk_chain/src/file_store.rs
+++ b/bdk_chain/src/file_store.rs
@@ -132,7 +132,7 @@ where
     pub fn set_derivation_indices(&mut self, indices: BTreeMap<K, u32>) -> Result<(), io::Error> {
         let keychain_changeset = KeychainChangeSet {
             chain_graph: Default::default(),
-            derivation_indices: indices,
+            derivation_indices: indices.into(),
         };
         self.append_changeset(&keychain_changeset)?;
 

--- a/bdk_chain/src/keychain/keychain_tracker.rs
+++ b/bdk_chain/src/keychain/keychain_tracker.rs
@@ -59,7 +59,7 @@ where
         scan: &KeychainScan<K, P>,
     ) -> Result<KeychainChangeSet<K, P>, chain_graph::UpdateError<P>> {
         let mut new_derivation_indices = scan.last_active_indexes.clone();
-        new_derivation_indices.retain(|keychain, index| {
+        new_derivation_indices.as_mut().retain(|keychain, index| {
             match self.txout_index.derivation_index(keychain) {
                 Some(existing) => *index > existing,
                 None => true,
@@ -83,7 +83,7 @@ where
 
     pub fn apply_changeset(&mut self, changeset: KeychainChangeSet<K, P>) {
         self.txout_index
-            .store_all_up_to(&changeset.derivation_indices);
+            .store_all_up_to(changeset.derivation_indices.as_ref());
         self.txout_index.scan(&changeset);
         self.chain_graph.apply_changeset(changeset.chain_graph)
     }

--- a/bdk_chain/src/keychain/keychain_tracker.rs
+++ b/bdk_chain/src/keychain/keychain_tracker.rs
@@ -82,7 +82,8 @@ where
     }
 
     pub fn apply_changeset(&mut self, changeset: KeychainChangeSet<K, P>) {
-        self.txout_index
+        let _ = self
+            .txout_index
             .store_all_up_to(changeset.derivation_indices.as_ref());
         self.txout_index.scan(&changeset);
         self.chain_graph.apply_changeset(changeset.chain_graph)

--- a/bdk_chain/tests/test_keychain_tracker.rs
+++ b/bdk_chain/tests/test_keychain_tracker.rs
@@ -29,7 +29,7 @@ fn test_insert_tx() {
         output: vec![txout],
     };
 
-    assert!(tracker.txout_index.store_up_to(&(), 5));
+    assert_eq!(tracker.txout_index.store_up_to(&(), 5), [((), 5)].into(),);
     let changeset = tracker
         .insert_tx_preview(tx.clone(), ConfirmationTime::Unconfirmed)
         .unwrap();
@@ -74,7 +74,13 @@ fn test_balance() {
         input: vec![],
         output: vec![TxOut {
             value: 13_000,
-            script_pubkey: tracker.txout_index.derive_new(&Keychain::One).1.clone(),
+            script_pubkey: tracker
+                .txout_index
+                .derive_new(&Keychain::One)
+                .0
+                .unwrap()
+                .1
+                .clone(),
         }],
     };
 
@@ -84,7 +90,13 @@ fn test_balance() {
         input: vec![],
         output: vec![TxOut {
             value: 7_000,
-            script_pubkey: tracker.txout_index.derive_new(&Keychain::Two).1.clone(),
+            script_pubkey: tracker
+                .txout_index
+                .derive_new(&Keychain::Two)
+                .0
+                .unwrap()
+                .1
+                .clone(),
         }],
     };
 
@@ -94,7 +106,13 @@ fn test_balance() {
         input: vec![TxIn::default()],
         output: vec![TxOut {
             value: 11_000,
-            script_pubkey: tracker.txout_index.derive_new(&Keychain::Two).1.clone(),
+            script_pubkey: tracker
+                .txout_index
+                .derive_new(&Keychain::Two)
+                .0
+                .unwrap()
+                .1
+                .clone(),
         }],
     };
 

--- a/bdk_chain/tests/test_keychain_txout_index.rs
+++ b/bdk_chain/tests/test_keychain_txout_index.rs
@@ -29,7 +29,10 @@ fn test_store_all_up_to() {
     let mut txout_index = init_txout_index();
     let derive_to: BTreeMap<_, _> =
         [(TestKeychain::External, 12), (TestKeychain::Internal, 24)].into();
-    assert!(txout_index.store_all_up_to(&derive_to));
+    assert_eq!(
+        txout_index.store_all_up_to(&derive_to),
+        [(TestKeychain::External, 12), (TestKeychain::Internal, 24)].into()
+    );
     assert_eq!(txout_index.derivation_indices(), derive_to);
 }
 
@@ -44,7 +47,10 @@ fn test_pad_all_with_unused() {
         .at_derivation_index(3)
         .script_pubkey();
 
-    assert!(txout_index.store_up_to(&TestKeychain::External, 3));
+    assert_eq!(
+        txout_index.store_up_to(&TestKeychain::External, 3),
+        [(TestKeychain::External, 3)].into(),
+    );
     txout_index.scan_txout(
         OutPoint::default(),
         &TxOut {
@@ -53,7 +59,10 @@ fn test_pad_all_with_unused() {
         },
     );
 
-    assert!(txout_index.pad_all_with_unused(5));
+    assert_eq!(
+        txout_index.pad_all_with_unused(5),
+        [(TestKeychain::External, 8), (TestKeychain::Internal, 4)].into(),
+    );
     assert_eq!(
         txout_index.derivation_indices(),
         [(TestKeychain::External, 8), (TestKeychain::Internal, 4)].into()

--- a/bdk_electrum_example/src/main.rs
+++ b/bdk_electrum_example/src/main.rs
@@ -111,7 +111,7 @@ fn main() -> anyhow::Result<()> {
 
             eprintln!();
 
-            keychain_changeset.derivation_indices = keychain_index_update;
+            keychain_changeset.derivation_indices = keychain_index_update.into();
 
             new_sparsechain
         }

--- a/bdk_esplora_example/src/esplora.rs
+++ b/bdk_esplora_example/src/esplora.rs
@@ -188,6 +188,7 @@ impl Client {
             if let Some(last_active_index) = last_active_index {
                 wallet_scan
                     .last_active_indexes
+                    .as_mut()
                     .insert(keychain, last_active_index);
             }
         }


### PR DESCRIPTION
Fixes #141

Main changes:
* Introduce `keychain::DerivationAdditions`. This can be used a indicies changeset or the actual indicies itself. The intention is to have a dedicated structure for the indicies changeset.
* `KeychainTxOutIndex` methods that mutate derivation indices now returns `DerivationAdditions`.

Bug fixes:
* Some `KeychainTxOutIndex` methods did not consider descriptors wildcards. This may lead to unexpected panic.

Other changes:
* Remove `KeychainStore::set_derivation_indices` as `append_changeset achieves the same goal.