### PR TITLE
Fix electrum example regtest url

### DIFF
--- a/bdk_electrum_example/src/main.rs
+++ b/bdk_electrum_example/src/main.rs
@@ -48,7 +48,7 @@ fn main() -> anyhow::Result<()> {
     let electrum_url = match args.network {
         Network::Bitcoin => "ssl://electrum.blockstream.info:50002",
         Network::Testnet => "ssl://electrum.blockstream.info:60002",
-        Network::Regtest => "ssl://localhost:60401",
+        Network::Regtest => "tcp://localhost:60401",
         Network::Signet => "tcp://signet-electrumx.wakiyamap.dev:50001",
     };
     let config = ConfigBuilder::new()


### PR DESCRIPTION
Local regtest electrs doesn't use SSL, so I had to change the `regtest` url to use tcp instead of ssl.

I confirmed this works using these steps:

1. install bitcoind via your favorite method

2. start regtest bitcoind
```
mkdir -p /tmp/regtest1/bitcoind
bitcoind -datadir=/tmp/regtest1/bitcoind -regtest -server -fallbackfee=0.0002 -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0 -blockfilterindex=1 -peerblockfilters=1 -daemon
```

cookie file location: /tmp/regtest1/bitcoind/regtest/.cookie

3. create test bitcoind wallet
```
bitcoin-cli -datadir=/tmp/regtest1/bitcoind -regtest createwallet "regtest1"
```

4. generate bitcoin blocks
```
bitcoin-cli -datadir=/tmp/regtest1/bitcoind -regtest getnewaddress
bitcoin-cli -datadir=/tmp/regtest1/bitcoind -regtest generatetoaddress 101 "<newaddress>"
```

5 install electrs (for mac m1)

```
brew install rocksdb
cargo install electrs --git https://github.com/romanz/electrs.git --branch bump-msrv
```

6. start electrs

```
mkdir -p /tmp/regtest1/electrs
electrs --db-dir /tmp/regtest1/electrs --daemon-dir /tmp/regtest1/bitcoind --cookie-file /tmp/regtest1/bitcoind/regtest/.cookie  --network regtest 
```

7. get new address (from bdk_electrum_example directory)
```
export DESCRIPTOR="tr(tprv8ZgxMBicQKsPd8kkvjJukqwX6TsEAEscD42chy8edbgFrdRUj72deq7PG4tsqnm3a7SjjBmRZ4F9p9ZSBsb5jKXhirHz2MxQcF2vVq1Xocr/0/*)"

cargo run -- --network regtest  address new
```

8. send coins to bdk_core wallet

```
bitcoin-cli -datadir=/tmp/regtest1/bitcoind -regtest generatetoaddress 10 "<new address>"
```

9. scan wallet addresses (from bdk_electrum_example directory)

```
cargo run -- --network regtest scan
```

10. check balance (from bdk_electrum_example directory)
```
cargo run -- --network regtest balance
```