### PR TITLE
Add mark and unmark used

### DIFF
--- a/bdk_chain/src/file_store.rs
+++ b/bdk_chain/src/file_store.rs
@@ -1,5 +1,4 @@
 use crate::{
-    collections::BTreeMap,
     keychain::{KeychainChangeSet, KeychainTracker},
     sparse_chain,
 };
@@ -157,17 +156,6 @@ where
         if !changeset.derivation_indices.is_empty() {
             self.db_file.sync_data()?;
         }
-
-        Ok(())
-    }
-
-    /// Appends a new changeset setting the derivation indicies
-    pub fn set_derivation_indices(&mut self, indices: BTreeMap<K, u32>) -> Result<(), io::Error> {
-        let keychain_changeset = KeychainChangeSet {
-            chain_graph: Default::default(),
-            derivation_indices: indices,
-        };
-        self.append_changeset(&keychain_changeset)?;
 
         Ok(())
     }

--- a/bdk_chain/src/keychain.rs
+++ b/bdk_chain/src/keychain.rs
@@ -63,12 +63,6 @@ impl<K> Default for DerivationAdditions<K> {
     }
 }
 
-// impl<K> From<BTreeMap<K, u32>> for DerivationAdditions<K> {
-//     fn from(value: BTreeMap<K, u32>) -> Self {
-//         Self(value)
-//     }
-// }
-
 impl<K: Ord, I> From<I> for DerivationAdditions<K>
 where
     I: IntoIterator<Item = (K, u32)>,

--- a/bdk_chain/src/keychain.rs
+++ b/bdk_chain/src/keychain.rs
@@ -102,6 +102,15 @@ impl<K, I> Default for KeychainScan<K, I> {
     }
 }
 
+impl<K, P> From<ChainGraph<P>> for KeychainScan<K, P> {
+    fn from(update: ChainGraph<P>) -> Self {
+        KeychainScan {
+            update,
+            last_active_indexes: Default::default(),
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 #[cfg_attr(
     feature = "serde",

--- a/bdk_chain/src/keychain/keychain_tracker.rs
+++ b/bdk_chain/src/keychain/keychain_tracker.rs
@@ -59,7 +59,7 @@ where
         scan: &KeychainScan<K, P>,
     ) -> Result<KeychainChangeSet<K, P>, chain_graph::UpdateError<P>> {
         let mut new_derivation_indices = scan.last_active_indexes.clone();
-        new_derivation_indices.retain(|keychain, index| {
+        new_derivation_indices.as_mut().retain(|keychain, index| {
             match self.txout_index.derivation_index(keychain) {
                 Some(existing) => *index > existing,
                 None => true,
@@ -82,8 +82,9 @@ where
     }
 
     pub fn apply_changeset(&mut self, changeset: KeychainChangeSet<K, P>) {
-        self.txout_index
-            .store_all_up_to(&changeset.derivation_indices);
+        let _ = self
+            .txout_index
+            .store_all_up_to(changeset.derivation_indices.as_ref());
         self.txout_index.scan(&changeset);
         self.chain_graph.apply_changeset(changeset.chain_graph)
     }

--- a/bdk_chain/src/keychain/keychain_txout_index.rs
+++ b/bdk_chain/src/keychain/keychain_txout_index.rs
@@ -77,8 +77,8 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     ///
     /// 1. After loading transaction data from disk you may scan over all the txouts to restore all
     /// your txouts.
-    /// 2. When getting new data from the chain you usually scan it before incoporating it into your
-    /// chain state.
+    /// 2. When getting new data from the chain you usually scan it before incorporating it into
+    /// your chain state (i.e. `SparseChain`, `ChainGraph`).
     ///
     /// See [`ForEachTxout`] for the types that support this.
     ///
@@ -163,8 +163,8 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
 
     /// Get the next derivation index for `keychain`.
     ///
-    /// The second field in the tuple represents whether the next derivation index is new. There are
-    /// two scenarios where the next derivation index is reused (not new):
+    /// The second field in the returned tuple represents whether the next derivation index is new.
+    /// There are two scenarios where the next derivation index is reused (not new):
     ///
     /// 1. The keychain's descriptor has no wildcard, and a script has already been derived.
     /// 2. The number of derived scripts has already reached 2^31 (refer to BIP-32).
@@ -197,7 +197,7 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
 
     /// Get the current derivation index for `keychain`.
     ///
-    /// This is the highest index in the keychain we have stored for `keychain`.
+    /// This is the highest index we have stored for `keychain`.
     pub fn derivation_index(&self, keychain: &K) -> Option<u32> {
         self.inner
             .script_pubkeys()
@@ -206,7 +206,7 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
             .map(|((_, index), _)| *index)
     }
 
-    /// Get the current derivation index for each keychain in the index.
+    /// Get the current derivation index for each keychain.
     ///
     /// Keychains with no indicies derived will not be included in the returned [`BTreeMap`].
     pub fn derivation_indices(&self) -> BTreeMap<K, u32> {
@@ -216,9 +216,7 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
             .collect()
     }
 
-    /// Convenience method to call [`derive_spks_up_to`] on several keychains.
-    ///
-    /// [`derive_spks_up_to`]: Self::store_up_to
+    /// Convenience method to call [`Self::store_up_to`] on several keychains.
     pub fn store_all_up_to(&mut self, keychains: &BTreeMap<K, u32>) -> DerivationAdditions<K> {
         let mut additions = DerivationAdditions::default();
         for (keychain, &index) in keychains {
@@ -318,11 +316,9 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
         }
     }
 
-    /// Convenience method to call [`pad_with_unused`] on all keychains.
+    /// Convenience method to call [`Self::pad_keychain_with_unused`] on all keychains.
     ///
     /// Returns whether any new scripts were derived.
-    ///
-    /// [`pad_with_unused`]: Self::pad_keychain_with_unused
     pub fn pad_all_with_unused(&mut self, pad_len: u32) -> DerivationAdditions<K> {
         let keychains = self.keychains.clone().into_keys();
 

--- a/bdk_chain/src/keychain/keychain_txout_index.rs
+++ b/bdk_chain/src/keychain/keychain_txout_index.rs
@@ -316,6 +316,28 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
         }
     }
 
+    /// Marks the script pubkey at `index` as used even though it hasn't seen an output with it.
+    /// This only has an effect when the `index` had been added to `self` already and was unused.
+    ///
+    /// This is useful when you want to reserve a script pubkey for something but don't want to add
+    /// the transaction output using it to the index yet. Other callers will consider `index` on
+    /// `keychain` used until you call [`unmark_used`].
+    ///
+    /// [`unmark_used`]: Self::unmark_used
+    pub fn mark_used(&mut self, keychain: &K, index: u32) {
+        self.inner.mark_used(&(keychain.clone(), index))
+    }
+
+    /// Undoes the effect of [`mark_used`].
+    ///
+    /// Note that if `self` has scanned an output with this script pubkey then this will have no
+    /// effect.
+    ///
+    /// [`mark_used`]: Self::mark_used
+    pub fn unmark_used(&mut self, keychain: &K, index: u32) {
+        self.inner.unmark_used(&(keychain.clone(), index));
+    }
+
     /// Convenience method to call [`Self::pad_keychain_with_unused`] on all keychains.
     ///
     /// Returns whether any new scripts were derived.

--- a/bdk_chain/src/spk_txout_index.rs
+++ b/bdk_chain/src/spk_txout_index.rs
@@ -197,6 +197,30 @@ impl<I: Clone + Ord> SpkTxOutIndex<I> {
         self.unused.get(index).is_none()
     }
 
+    /// Marks the script pubkey at `index` as used even though it hasn't seen an output with it.
+    /// This only has an effect when the `index` had been added to `self` already and was unused.
+    ///
+    /// This is useful when you want to reserve a script pubkey for something but don't want to add
+    /// the transaction output using it to the index yet. Other callers will consider `index` used
+    /// until you call [`unmark_used`].
+    ///
+    /// [`unmark_used`]: Self::unmark_used
+    pub fn mark_used(&mut self, index: &I) {
+        self.unused.remove(index);
+    }
+
+    /// Undoes the effect of [`mark_used`].
+    ///
+    /// Note that if `self` has scanned an output with this script pubkey then this will have no
+    /// effect.
+    ///
+    /// [`mark_used`]: Self::mark_used
+    pub fn unmark_used(&mut self, index: &I) {
+        if self.outputs_in_range(index..=index).next().is_none() {
+            self.unused.insert(index.clone());
+        }
+    }
+
     /// Returns the index associated with the script pubkey.
     pub fn index_of_spk(&self, script: &Script) -> Option<I> {
         self.spk_indexes.get(script).cloned()

--- a/bdk_chain/tests/test_keychain_tracker.rs
+++ b/bdk_chain/tests/test_keychain_tracker.rs
@@ -29,7 +29,7 @@ fn test_insert_tx() {
         output: vec![txout],
     };
 
-    assert!(tracker.txout_index.store_up_to(&(), 5));
+    assert_eq!(tracker.txout_index.store_up_to(&(), 5), [((), 5)].into(),);
     let changeset = tracker
         .insert_tx_preview(tx.clone(), ConfirmationTime::Unconfirmed)
         .unwrap();
@@ -74,7 +74,7 @@ fn test_balance() {
         input: vec![],
         output: vec![TxOut {
             value: 13_000,
-            script_pubkey: tracker.txout_index.derive_new(&Keychain::One).1.clone(),
+            script_pubkey: tracker.txout_index.derive_new(&Keychain::One).0 .1.clone(),
         }],
     };
 
@@ -84,7 +84,7 @@ fn test_balance() {
         input: vec![],
         output: vec![TxOut {
             value: 7_000,
-            script_pubkey: tracker.txout_index.derive_new(&Keychain::Two).1.clone(),
+            script_pubkey: tracker.txout_index.derive_new(&Keychain::Two).0 .1.clone(),
         }],
     };
 
@@ -94,7 +94,7 @@ fn test_balance() {
         input: vec![TxIn::default()],
         output: vec![TxOut {
             value: 11_000,
-            script_pubkey: tracker.txout_index.derive_new(&Keychain::Two).1.clone(),
+            script_pubkey: tracker.txout_index.derive_new(&Keychain::Two).0 .1.clone(),
         }],
     };
 

--- a/bdk_chain/tests/test_keychain_txout_index.rs
+++ b/bdk_chain/tests/test_keychain_txout_index.rs
@@ -1,7 +1,11 @@
 #![cfg(feature = "miniscript")]
 
-use bdk_chain::collections::BTreeMap;
-use bitcoin::{OutPoint, TxOut};
+#[macro_use]
+mod common;
+use bdk_chain::{collections::BTreeMap, keychain::KeychainTxOutIndex};
+use bitcoin::{hashes::hex::FromHex, OutPoint, Script, TxOut};
+
+use miniscript::{Descriptor, DescriptorPublicKey};
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 enum TestKeychain {
@@ -10,8 +14,6 @@ enum TestKeychain {
 }
 
 fn init_txout_index() -> bdk_chain::keychain::KeychainTxOutIndex<TestKeychain> {
-    use miniscript::{Descriptor, DescriptorPublicKey};
-
     let mut txout_index = bdk_chain::keychain::KeychainTxOutIndex::<TestKeychain>::default();
 
     let secp = bdk_chain::bitcoin::secp256k1::Secp256k1::signing_only();
@@ -24,12 +26,31 @@ fn init_txout_index() -> bdk_chain::keychain::KeychainTxOutIndex<TestKeychain> {
     txout_index
 }
 
+fn mark_used(tracker: &mut KeychainTxOutIndex<TestKeychain>, index: &(TestKeychain, u32)) {
+    let op = OutPoint {
+        txid: h!("dangling"),
+        vout: 0,
+    };
+    let txout = TxOut {
+        value: 1,
+        script_pubkey: tracker
+            .spk_at_index(index)
+            .expect("bad keychain, or script not derived")
+            .clone(),
+    };
+    tracker.scan_txout(op, &txout);
+    assert!(tracker.is_used(index));
+}
+
 #[test]
 fn test_store_all_up_to() {
     let mut txout_index = init_txout_index();
     let derive_to: BTreeMap<_, _> =
         [(TestKeychain::External, 12), (TestKeychain::Internal, 24)].into();
-    assert!(txout_index.store_all_up_to(&derive_to));
+    assert_eq!(
+        txout_index.store_all_up_to(&derive_to),
+        [(TestKeychain::External, 12), (TestKeychain::Internal, 24)].into()
+    );
     assert_eq!(txout_index.derivation_indices(), derive_to);
 }
 
@@ -44,7 +65,10 @@ fn test_pad_all_with_unused() {
         .at_derivation_index(3)
         .script_pubkey();
 
-    assert!(txout_index.store_up_to(&TestKeychain::External, 3));
+    assert_eq!(
+        txout_index.store_up_to(&TestKeychain::External, 3),
+        [(TestKeychain::External, 3)].into(),
+    );
     txout_index.scan_txout(
         OutPoint::default(),
         &TxOut {
@@ -53,9 +77,234 @@ fn test_pad_all_with_unused() {
         },
     );
 
-    assert!(txout_index.pad_all_with_unused(5));
+    assert_eq!(
+        txout_index.pad_all_with_unused(5),
+        [(TestKeychain::External, 8), (TestKeychain::Internal, 4)].into(),
+    );
     assert_eq!(
         txout_index.derivation_indices(),
         [(TestKeychain::External, 8), (TestKeychain::Internal, 4)].into()
+    );
+}
+
+#[test]
+fn test_wildcard_derivations() {
+    let mut txout_index = init_txout_index();
+
+    // Stage 1
+    // - nothing is derived
+    // - unused list is also empty
+    //
+    // - next_derivation_index() == (0, true)
+    // - derive_new() == ((0, <spk>), DerivationAdditions)
+    // - next_unused() == ((0, <spk>), DerivationAdditions:is_empty())
+    assert_eq!(
+        txout_index.next_derivation_index(&TestKeychain::External),
+        (0, true)
+    );
+    assert_eq!(
+        txout_index.derive_new(&TestKeychain::External),
+        (
+            (
+                0,
+                &Script::from_hex(
+                    "5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c"
+                )
+                .unwrap()
+            ),
+            [(TestKeychain::External, 0)].into()
+        )
+    );
+    assert_eq!(
+        txout_index.next_unused(&TestKeychain::External),
+        (
+            (
+                0,
+                &Script::from_hex(
+                    "5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c"
+                )
+                .unwrap()
+            ),
+            [].into()
+        )
+    );
+
+    // Stage - 2
+    // - derived till 25
+    // - used all spks till 15.
+    // - used list : [0..=15, 17, 20, 23]
+    // - unused list: [16, 18, 19, 21, 22, 24, 25]
+
+    // - next_derivation_index() = (26, true)
+    // - derive_new() = ((26, <spk>), DerivationAdditions)
+    // - next_unused() == ((16, <spk>), DerivationAdditions::is_empty())
+    let _ = txout_index.store_up_to(&TestKeychain::External, 25);
+
+    (0..=15)
+        .into_iter()
+        .chain([17, 20, 23].into_iter())
+        .for_each(|index| mark_used(&mut txout_index, &(TestKeychain::External, index)));
+
+    assert_eq!(
+        txout_index.next_derivation_index(&TestKeychain::External),
+        (26, true)
+    );
+    assert_eq!(
+        txout_index.derive_new(&TestKeychain::External),
+        (
+            (
+                26,
+                &Script::from_hex(
+                    "512017561301dafcfe66d9a757d9907b05646c9c1fcab57069f7917d0af3116661ee"
+                )
+                .unwrap()
+            ),
+            [(TestKeychain::External, 26)].into()
+        )
+    );
+    assert_eq!(
+        txout_index.next_unused(&TestKeychain::External),
+        (
+            (
+                16,
+                &Script::from_hex(
+                    "5120c0926db156acc59de0a5685b47ff6663edc37df9bbde9cf504ebe39568cb4644"
+                )
+                .unwrap()
+            ),
+            [].into()
+        )
+    );
+
+    // Stage -3
+    // - Use all the derived till 26.
+    // - next_unused() = ((27, <spk>), DerivationAdditions)
+    (0..=26)
+        .into_iter()
+        .for_each(|index| mark_used(&mut txout_index, &(TestKeychain::External, index)));
+
+    assert_eq!(
+        txout_index.next_unused(&TestKeychain::External),
+        (
+            (
+                27,
+                &Script::from_hex(
+                    "512090f6ddcb6c1bd1482166b941a86e9663b44d889ab7e5ffce1c5185658d894bf3"
+                )
+                .unwrap()
+            ),
+            [(TestKeychain::External, 27)].into()
+        )
+    );
+
+    /*
+    Stage 4 and Stage 5 is commented out as they test behavior at numeric bound
+    which takes a long time to run an can exhaust memory pretty quickly.
+
+    included here for documenting only.
+
+    // Stage  4
+    // Derived scripts at numeric bound.
+    //
+    // - next_derivation_index() = (Max, false)
+    // - derive_new() == ((Max, <spk>), DerivationAdditions::is_empty())
+    // - next_unused() == ((27, <spk>), DerivationAdditions::is_empty())
+    let _ = txout_index.store_up_to(&TestKeychain::External, u32::MAX);
+
+    assert_eq!(
+        txout_index.next_derivation_index(&TestKeychain::External),
+        (u32::MAX, false)
+    );
+    assert_eq!(
+        txout_index.derive_new(&TestKeychain::External).1, [].into()
+    );
+    assert_eq!(
+        txout_index.next_unused(&TestKeychain::External).1, [].into()
+    );
+
+    // Stage 5
+    // Used scripts at numeric bound. No unused script left. Can't derive either.
+    // - next_unused() == ((Max, <spk>), DerivationAdditions::is_empty())
+    (0..=u32::MAX).into_iter().for_each(|index| mark_used(&mut txout_index, &(TestKeychain::External, index)));
+    assert_eq!(
+        txout_index.next_unused(&TestKeychain::External).1, [].into()
+    );
+
+    */
+}
+
+#[test]
+fn test_non_wildcard_derivations() {
+    let mut txout_index = KeychainTxOutIndex::<TestKeychain>::default();
+
+    let secp = bitcoin::secp256k1::Secp256k1::signing_only();
+    let (no_wildcard_descriptor, _) = Descriptor::<DescriptorPublicKey>::parse_descriptor(&secp, "wpkh([73c5da0a/86'/0'/0']xprv9xgqHN7yz9MwCkxsBPN5qetuNdQSUttZNKw1dcYTV4mkaAFiBVGQziHs3NRSWMkCzvgjEe3n9xV8oYywvM8at9yRqyaZVz6TYYhX98VjsUk/1/0)").unwrap();
+
+    txout_index.add_keychain(TestKeychain::External, no_wildcard_descriptor);
+
+    // Stage 1
+    // nothing derived
+    // no unused scripts
+    //
+    // - next_derivation_index() = (0, true)
+    // - derive_new() = ((0, <spk>), DerivationAdditions)
+    // - next_unused() = ((0, <spk>), DerivationAdditions::is_empty())
+    assert_eq!(
+        txout_index.next_derivation_index(&TestKeychain::External),
+        (0, true)
+    );
+    assert_eq!(
+        txout_index.derive_new(&TestKeychain::External),
+        (
+            (
+                0,
+                &Script::from_hex("0014dd494ba8f622f9ae256d2d58bc48214a6d4819f7").unwrap()
+            ),
+            [(TestKeychain::External, 0)].into()
+        )
+    );
+    assert_eq!(
+        txout_index.next_unused(&TestKeychain::External),
+        (
+            (
+                0,
+                &Script::from_hex("0014dd494ba8f622f9ae256d2d58bc48214a6d4819f7").unwrap()
+            ),
+            [].into()
+        )
+    );
+
+    // Stage 2
+    // Mark the single spk as used
+    //
+    // - next_derivation_index() == (0, false)
+    // - derive_new() = ((0, <spk>), DerivationAdditions::is_empty())
+    // - next_unused() = ((0, <spk>), DerivationAdditions::is_empty())
+
+    mark_used(&mut txout_index, &(TestKeychain::External, 0));
+
+    assert_eq!(
+        txout_index.next_derivation_index(&TestKeychain::External),
+        (0, false)
+    );
+    assert_eq!(
+        txout_index.derive_new(&TestKeychain::External),
+        (
+            (
+                0,
+                &Script::from_hex("0014dd494ba8f622f9ae256d2d58bc48214a6d4819f7").unwrap()
+            ),
+            [].into()
+        )
+    );
+    assert_eq!(
+        txout_index.next_unused(&TestKeychain::External),
+        (
+            (
+                0,
+                &Script::from_hex("0014dd494ba8f622f9ae256d2d58bc48214a6d4819f7").unwrap()
+            ),
+            [].into()
+        )
     );
 }

--- a/bdk_chain/tests/test_spk_txout_index.rs
+++ b/bdk_chain/tests/test_spk_txout_index.rs
@@ -54,3 +54,39 @@ fn spk_txout_sent_and_received() {
     assert_eq!(index.sent_and_received(&tx2), (42_000, 50_000));
     assert_eq!(index.net_value(&tx2), 8_000);
 }
+
+#[test]
+fn mark_used() {
+    let spk1 = Script::from_hex("001404f1e52ce2bab3423c6a8c63b7cd730d8f12542c").unwrap();
+    let spk2 = Script::from_hex("00142b57404ae14f08c3a0c903feb2af7830605eb00f").unwrap();
+
+    let mut spk_index = SpkTxOutIndex::default();
+    spk_index.insert_script_pubkey(1, spk1.clone());
+    spk_index.insert_script_pubkey(2, spk2.clone());
+
+    assert_eq!(spk_index.is_used(&1), false);
+    spk_index.mark_used(&1);
+    assert_eq!(spk_index.is_used(&1), true);
+    spk_index.unmark_used(&1);
+    assert_eq!(spk_index.is_used(&1), false);
+    spk_index.mark_used(&1);
+    assert_eq!(spk_index.is_used(&1), true);
+
+    let tx1 = Transaction {
+        version: 0x02,
+        lock_time: PackedLockTime(0),
+        input: vec![],
+        output: vec![TxOut {
+            value: 42_000,
+            script_pubkey: spk1.clone(),
+        }],
+    };
+
+    spk_index.scan(&tx1);
+    spk_index.unmark_used(&1);
+    assert_eq!(
+        spk_index.is_used(&1),
+        true,
+        "even though we unmark_used it doesn't matter because there was a tx scanned that used it"
+    );
+}

--- a/bdk_cli_lib/src/lib.rs
+++ b/bdk_cli_lib/src/lib.rs
@@ -8,7 +8,7 @@ use bdk_chain::{
     },
     descriptor_ext::DescriptorExt,
     file_store::KeychainStore,
-    keychain::{KeychainChangeSet, KeychainTracker},
+    keychain::{DerivationAdditions, KeychainChangeSet, KeychainTracker},
     miniscript::{
         descriptor::{DescriptorSecretKey, KeyMap},
         Descriptor, DescriptorPublicKey,
@@ -174,16 +174,17 @@ where
 {
     let txout_index = &mut keychain_tracker.txout_index;
 
-    let new_address = match addr_cmd {
+    let addr_cmmd_output = match addr_cmd {
         AddressCmd::Next => Some(txout_index.next_unused(&Keychain::External)),
         AddressCmd::New => Some(txout_index.derive_new(&Keychain::External)),
         _ => None,
     };
 
-    if let Some((index, spk)) = new_address {
-        let spk = spk.clone();
+    if let Some(((index, spk), additions)) = addr_cmmd_output {
         // update database since we're about to give out a new address
-        db.set_derivation_indices(txout_index.derivation_indices())?;
+        db.append_changeset(&additions.into())?;
+
+        let spk = spk.clone();
         let address =
             Address::from_script(&spk, network).expect("should always be able to derive address");
         eprintln!("This is the address at index {}", index);
@@ -267,7 +268,9 @@ pub fn create_tx<P: ChainPosition>(
     coin_select: CoinSelectionAlgo,
     keychain_tracker: &mut KeychainTracker<Keychain, P>,
     keymap: &HashMap<DescriptorPublicKey, DescriptorSecretKey>,
-) -> Result<Transaction> {
+) -> Result<(Transaction, DerivationAdditions<Keychain>)> {
+    let mut additions = DerivationAdditions::default();
+
     let assets = bdk_tmp_plan::Assets {
         keys: keymap.iter().map(|(pk, _)| pk.clone()).collect(),
         ..Default::default()
@@ -319,10 +322,13 @@ pub fn create_tx<P: ChainPosition>(
         Keychain::External
     };
 
-    let (change_index, change_script) = {
-        let (index, script) = keychain_tracker.txout_index.next_unused(&internal_keychain);
-        (index, script.clone())
-    };
+    let ((change_index, change_script), change_additions) =
+        keychain_tracker.txout_index.next_unused(&internal_keychain);
+    additions.append(change_additions);
+
+    // Clone to drop the immutable reference.
+    let change_script = change_script.clone();
+
     let change_plan = bdk_tmp_plan::plan_satisfaction(
         &keychain_tracker
             .txout_index
@@ -336,7 +342,7 @@ pub fn create_tx<P: ChainPosition>(
 
     let mut change_output = TxOut {
         value: 0,
-        script_pubkey: change_script,
+        script_pubkey: change_script.clone(),
     };
 
     let cs_opts = CoinSelectorOpt {
@@ -456,7 +462,7 @@ pub fn create_tx<P: ChainPosition>(
         }
     }
 
-    Ok(transaction)
+    Ok((transaction, additions))
 }
 
 pub trait Broadcast {
@@ -492,12 +498,15 @@ where
             address,
             coin_select,
         } => {
-            let transaction = create_tx(value, address, coin_select, tracker, &keymap)?;
-            let changeset = tracker.insert_tx(transaction.clone(), P::unconfirmed())?;
+            let (transaction, additions) =
+                create_tx(value, address, coin_select, tracker, &keymap)?;
+            let mut changeset = tracker.insert_tx(transaction.clone(), P::unconfirmed())?;
+            changeset.derivation_indices.append(additions);
+
             client.broadcast(&transaction)?;
+
             // We only want to store the changeset if we actually successfully broadcasted because
             // it will increase the derivation index of the internal keychain.
-            store.set_derivation_indices(tracker.txout_index.derivation_indices())?;
             store.append_changeset(&changeset)?;
             println!("Broadcasted Tx : {}", transaction.txid());
         }

--- a/bdk_cli_lib/src/lib.rs
+++ b/bdk_cli_lib/src/lib.rs
@@ -1,11 +1,12 @@
 pub extern crate anyhow;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use bdk_chain::{
     bitcoin::{
         secp256k1::Secp256k1,
         util::sighash::{Prevouts, SighashCache},
         Address, LockTime, Network, Sequence, Transaction, TxIn, TxOut,
     },
+    chain_graph::InsertTxError,
     descriptor_ext::DescriptorExt,
     file_store::KeychainStore,
     keychain::{DerivationAdditions, KeychainChangeSet, KeychainTracker},
@@ -19,7 +20,9 @@ use bdk_chain::{
 use bdk_coin_select::{coin_select_bnb, CoinSelector, CoinSelectorOpt, WeightedValue};
 pub use clap;
 use clap::{Parser, Subcommand};
-use std::{cmp::Reverse, collections::HashMap, fmt::Debug, path::PathBuf, time::Duration};
+use std::{
+    cmp::Reverse, collections::HashMap, fmt::Debug, path::PathBuf, sync::Mutex, time::Duration,
+};
 
 #[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
@@ -163,8 +166,8 @@ pub struct AddrsOutput {
 }
 
 pub fn run_address_cmd<P>(
-    keychain_tracker: &mut KeychainTracker<Keychain, P>,
-    db: &mut KeychainStore<Keychain, P>,
+    tracker: &Mutex<KeychainTracker<Keychain, P>>,
+    db: &Mutex<KeychainStore<Keychain, P>>,
     addr_cmd: AddressCmd,
     network: Network,
 ) -> Result<()>
@@ -172,7 +175,8 @@ where
     P: sparse_chain::ChainPosition,
     KeychainChangeSet<Keychain, P>: serde::Serialize + serde::de::DeserializeOwned,
 {
-    let txout_index = &mut keychain_tracker.txout_index;
+    let mut tracker = tracker.lock().unwrap();
+    let txout_index = &mut tracker.txout_index;
 
     let addr_cmmd_output = match addr_cmd {
         AddressCmd::Next => Some(txout_index.next_unused(&Keychain::External)),
@@ -181,6 +185,7 @@ where
     };
 
     if let Some(((index, spk), additions)) = addr_cmmd_output {
+        let mut db = db.lock().unwrap();
         // update database since we're about to give out a new address
         db.append_changeset(&additions.into())?;
 
@@ -222,9 +227,10 @@ where
     }
 }
 
-pub fn run_balance_cmd<P: ChainPosition>(keychain_tracker: &KeychainTracker<Keychain, P>) {
+pub fn run_balance_cmd<P: ChainPosition>(tracker: &Mutex<KeychainTracker<Keychain, P>>) {
+    let tracker = tracker.lock().unwrap();
     let (confirmed, unconfirmed) =
-        keychain_tracker
+        tracker
             .full_utxos()
             .fold((0, 0), |(confirmed, unconfirmed), (_, utxo)| {
                 if utxo.chain_position.height().is_confirmed() {
@@ -240,12 +246,13 @@ pub fn run_balance_cmd<P: ChainPosition>(keychain_tracker: &KeychainTracker<Keyc
 
 pub fn run_txo_cmd<K: Debug + Clone + Ord, P: ChainPosition>(
     txout_cmd: TxOutCmd,
-    keychain_tracker: &KeychainTracker<K, P>,
+    tracker: &Mutex<KeychainTracker<K, P>>,
     network: Network,
 ) {
     match txout_cmd {
         TxOutCmd::List => {
-            for (spk_index, full_txout) in keychain_tracker.full_txouts() {
+            let tracker = tracker.lock().unwrap();
+            for (spk_index, full_txout) in tracker.full_txouts() {
                 let address =
                     Address::from_script(&full_txout.txout.script_pubkey, network).unwrap();
 
@@ -268,7 +275,10 @@ pub fn create_tx<P: ChainPosition>(
     coin_select: CoinSelectionAlgo,
     keychain_tracker: &mut KeychainTracker<Keychain, P>,
     keymap: &HashMap<DescriptorPublicKey, DescriptorSecretKey>,
-) -> Result<(Transaction, DerivationAdditions<Keychain>)> {
+) -> Result<(
+    Transaction,
+    Option<(DerivationAdditions<Keychain>, (Keychain, u32))>,
+)> {
     let mut additions = DerivationAdditions::default();
 
     let assets = bdk_tmp_plan::Assets {
@@ -462,7 +472,13 @@ pub fn create_tx<P: ChainPosition>(
         }
     }
 
-    Ok((transaction, additions))
+    let change_info = if selection_meta.drain_value.is_some() {
+        Some((additions, (internal_keychain, change_index)))
+    } else {
+        None
+    };
+
+    Ok((transaction, change_info))
 }
 
 pub trait Broadcast {
@@ -473,8 +489,10 @@ pub trait Broadcast {
 pub fn handle_commands<C: clap::Subcommand, P>(
     command: Commands<C>,
     client: impl Broadcast,
-    tracker: &mut KeychainTracker<Keychain, P>,
-    store: &mut KeychainStore<Keychain, P>,
+    // we Mutexes around these not because we need them for a simple CLI app but to demonsrate how
+    // all the stuff we're doing can be thread safe and also not keep locks up over an IO bound.
+    tracker: &Mutex<KeychainTracker<Keychain, P>>,
+    store: &Mutex<KeychainStore<Keychain, P>>,
     network: Network,
     keymap: &HashMap<DescriptorPublicKey, DescriptorSecretKey>,
 ) -> Result<()>
@@ -484,45 +502,89 @@ where
 {
     match command {
         // TODO: Make these functions return stuffs
-        Commands::Address { addr_cmd } => {
-            run_address_cmd(tracker, store, addr_cmd, network)?;
-        }
+        Commands::Address { addr_cmd } => run_address_cmd(&tracker, &store, addr_cmd, network),
         Commands::Balance => {
             run_balance_cmd(&tracker);
+            Ok(())
         }
         Commands::TxOut { txout_cmd } => {
-            run_txo_cmd(txout_cmd, tracker, network);
+            run_txo_cmd(txout_cmd, &tracker, network);
+            Ok(())
         }
         Commands::Send {
             value,
             address,
             coin_select,
         } => {
-            let (transaction, additions) =
-                create_tx(value, address, coin_select, tracker, &keymap)?;
-            let mut changeset = tracker.insert_tx(transaction.clone(), P::unconfirmed())?;
-            changeset.derivation_indices.append(additions);
+            let (transaction, change_index) = {
+                // take mutable ref to construct tx -- it is only open for a short time while building it.
+                let tracker = &mut *tracker.lock().unwrap();
+                let (transaction, change_info) =
+                    create_tx(value, address, coin_select, tracker, &keymap)?;
 
-            client.broadcast(&transaction)?;
+                if let Some((change_derivation_changes, (change_keychain, index))) = change_info {
+                    // We must first persist to disk the fact that we've got a new address from the
+                    // change keychain so future scans will find the tx we're about to broadcast.
+                    // If we're unable to persist this then we don't want to broadcast.
+                    let store = &mut *store.lock().unwrap();
+                    store.append_changeset(&change_derivation_changes.into())?;
 
-            // We only want to store the changeset if we actually successfully broadcasted because
-            // it will increase the derivation index of the internal keychain.
-            store.append_changeset(&changeset)?;
-            println!("Broadcasted Tx : {}", transaction.txid());
+                    // We don't want other callers/threads to use this address while we're using it
+                    // but we also don't want to scan the tx we just created because it's not
+                    // technically in the blockchain yet.
+                    tracker.txout_index.mark_used(&change_keychain, index);
+                    (transaction, Some((change_keychain, index)))
+                } else {
+                    (transaction, None)
+                }
+            };
+
+            match client.broadcast(&transaction) {
+                Ok(_) => {
+                    println!("Broadcasted Tx : {}", transaction.txid());
+                    let mut tracker = tracker.lock().unwrap();
+                    match tracker.insert_tx(transaction.clone(), P::unconfirmed()) {
+                        Ok(changeset) => {
+                            let store = &mut *store.lock().unwrap();
+                            // We know the tx is at least unconfirmed now. Note if persisting here
+                            // fails it's not a big deal since we can always find it again form
+                            // blockchain.
+                            store.append_changeset(&changeset)?;
+                            Ok(())
+                        }
+                        Err(e) => match e {
+                            InsertTxError::Chain(e) => match e {
+                                // TODO: add insert_unconfirmed_tx to chain graph and sparse chain
+                                sparse_chain::InsertTxError::TxTooHigh { .. } => unreachable!("we are inserting at unconfirmed position"),
+                                sparse_chain::InsertTxError::TxMovedUnexpectedly { txid, original_pos, ..} => Err(anyhow!("the tx we created {} has already been confirmed at block {:?}", txid, original_pos)),
+                            },
+                            InsertTxError::UnresolvableConflict(e) => Err(e).context("another tx that conflicts with the one we tried to create has been confirmed"),
+                        }
+                    }
+                }
+                Err(e) => {
+                    let tracker = &mut *tracker.lock().unwrap();
+                    if let Some((keychain, index)) = change_index {
+                        // We failed to broadcast so allow our change address to be used in the future
+                        tracker.txout_index.unmark_used(&keychain, index);
+                    }
+                    Err(e.into())
+                }
+            }
         }
         Commands::ChainSpecific(_) => {
             todo!("example code is meant to handle this!")
         }
     }
-
-    Ok(())
 }
 
 pub fn init<C: clap::Subcommand, P>() -> anyhow::Result<(
     Args<C>,
     KeyMap,
-    KeychainTracker<Keychain, P>,
-    KeychainStore<Keychain, P>,
+    // These don't need to have mutexes around them but we want the cli example code to make it obvious how they
+    // are thread safe so this forces the example developer to show where they would lock and unlock things.
+    Mutex<KeychainTracker<Keychain, P>>,
+    Mutex<KeychainStore<Keychain, P>>,
 )>
 where
     P: sparse_chain::ChainPosition,
@@ -563,7 +625,7 @@ where
         eprintln!("⚠ Consider running a rescan of chain data.");
     }
 
-    Ok((args, keymap, tracker, db))
+    Ok((args, keymap, Mutex::new(tracker), Mutex::new(db)))
 }
 
 pub fn planned_utxos<'a, AK: bdk_tmp_plan::CanDerive + Clone, P: ChainPosition>(

--- a/bdk_electrum_example/src/main.rs
+++ b/bdk_electrum_example/src/main.rs
@@ -111,7 +111,7 @@ fn main() -> anyhow::Result<()> {
 
             eprintln!();
 
-            keychain_changeset.derivation_indices = keychain_index_update;
+            keychain_changeset.derivation_indices = keychain_index_update.into();
 
             new_sparsechain
         }

--- a/bdk_esplora_example/src/esplora.rs
+++ b/bdk_esplora_example/src/esplora.rs
@@ -188,6 +188,7 @@ impl Client {
             if let Some(last_active_index) = last_active_index {
                 wallet_scan
                     .last_active_indexes
+                    .as_mut()
                     .insert(keychain, last_active_index);
             }
         }


### PR DESCRIPTION
This is on top of #154. I felt that the point of that PR was to finally demonstrate how to do broadcasting and updating the db in a safe way. I realized while reviewing it that there was still unfinished business here so I went ahead and implemented the missing pieces: `mark` and `unmark` unused.

I also made the examples take `Mutex`s around `KeychainTracker` etc so the example code has to force itself to be thread safe. This demonsrates points where we are keeping a lock on the tracker or db for longer than necessary or not long enough.

I found two problems with the way we were doing things:
1. In the `Commands::Send` broadcast code we were  creating a changeset before brodacasting and storing it after. This might be a mistake unless you are willing to keep the lock over the broadcast call because by the time the broadcast has finished another thread may have made stored something else before it (this could potentially leave the tracker in an invalid state).
2. I found that in the `Sync` commands we were indeed keeping a lock over an entire sync and had to be rejigged a bit by first `collect`ing all the spks we are interested in into a `Vec` before passing them on.

So it turns out this path of not checking the validity of change sets does make things quite tricky.

I think we should merge #154 first.