### PR TITLE
Implement `KeychainTxOutIndex::apply_additions`

### DIFF
--- a/bdk_chain/src/keychain/keychain_txout_index.rs
+++ b/bdk_chain/src/keychain/keychain_txout_index.rs
@@ -261,7 +261,7 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
                 .insert_script_pubkey((keychain.clone(), index), spk);
         }
 
-        additions.as_mut().insert(keychain.clone(), end);
+        additions.last_derived.insert(keychain.clone(), end);
         additions
     }
 
@@ -406,6 +406,12 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
                     .map(|index| (keychain.clone(), index))
             })
             .collect()
+    }
+
+    /// Applies the derivation additions to the [`KeychainTxOutIndex`], extending the number of
+    /// derived scripts per keychain, as specified in the `additions`.
+    pub fn apply_additions(&mut self, additions: DerivationAdditions<K>) {
+        let _ = self.store_all_up_to(&additions.last_derived);
     }
 }
 

--- a/bdk_esplora_example/src/esplora.rs
+++ b/bdk_esplora_example/src/esplora.rs
@@ -188,7 +188,7 @@ impl Client {
             if let Some(last_active_index) = last_active_index {
                 wallet_scan
                     .last_active_indexes
-                    .as_mut()
+                    .last_derived
                     .insert(keychain, last_active_index);
             }
         }


### PR DESCRIPTION
Internally, this just uses `store_all_up_to`, however this will change once we start storing a "lookahead" index for each keychain.

Additionally, I have removed `AsRef` and `AsMut` implementations for ` DerivationAdditions`, and `DerivationAdditions` now has a single field `last_derived`.

---

This is my attempt at addressing https://github.com/LLFourn/bdk_core_staging/pull/154#issuecomment-1411479890