### PR TITLE
update esplora regtest API port

### DIFF
--- a/bdk_esplora_example/src/main.rs
+++ b/bdk_esplora_example/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> anyhow::Result<()> {
     let esplora_url = match args.network {
         Network::Bitcoin => "https://mempool.space/api",
         Network::Testnet => "https://mempool.space/testnet/api",
-        Network::Regtest => "http://localhost:3000",
+        Network::Regtest => "http://localhost:3002",
         Network::Signet => "https://mempool.space/signet/api",
     };
 


### PR DESCRIPTION
This PR updates the Esplora regtest port from `3000` to `3002`.

I was able to setup manual testing following @notmandatory electrum example by following these instructions.

1. install bitcoind via your favorite method

2. start regtest bitcoind

```
mkdir -p /tmp/regtest1/bitcoind
bitcoind -datadir=/tmp/regtest1/bitcoind -regtest -server -fallbackfee=0.0002 -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0 -blockfilterindex=1 -peerblockfilters=1 -daemon -rpccookiefile=/tmp/regtest1/bitcoind/regtest/.cookie
```

3. create test bitcoind wallet

```
bitcoin-cli -datadir=/tmp/regtest1/bitcoind -regtest createwallet "regtest1"
```

4.  generate bitcoin blocks

```
bitcoin-cli -datadir=/tmp/regtest1/bitcoind -regtest getnewaddress
bitcoin-cli -datadir=/tmp/regtest1/bitcoind -regtest generatetoaddress 101 "<newaddress>"
```

5. install and run electrs-esplora

```
git clone https://github.com/blockstream/electrs && cd electrs
git checkout new-index
cargo run --release --bin electrs -- -vvvv --daemon-dir /tmp/regtest1/bitcoind --network regtest
```

6. get new address (from bdk_esplora_example directory)

```
export DESCRIPTOR="tr(tprv8ZgxMBicQKsPd8kkvjJukqwX6TsEAEscD42chy8edbgFrdRUj72deq7PG4tsqnm3a7SjjBmRZ4F9p9ZSBsb5jKXhirHz2MxQcF2vVq1Xocr/0/*)"

cargo run -- --network regtest  address new
```

7. send coins to bdk_core wallet

```
bitcoin-cli -datadir=/tmp/regtest1/bitcoind -regtest generatetoaddress 10 "<new address>"
```

8. scan wallet addresses (from bdk_esplora_example directory)

```
cargo run -- --network regtest scan
```

9. check balance (from bdk_esplora_example directory)

```
cargo run -- --network regtest balance
```