### PR TITLE
Add Coin Grouping to CoinSelection

### DIFF
--- a/bdk_coin_select/Cargo.toml
+++ b/bdk_coin_select/Cargo.toml
@@ -6,6 +6,7 @@ authors = [ "LLFourn <lloyd.fourn@gmail.com>" ]
 
 [dependencies]
 bdk_chain = { path = "../bdk_chain" }
+bdk_tmp_plan = { path = "../bdk_tmp_plan" }
 
 [features]
 default = ["std"]

--- a/bdk_coin_select/src/coin_grouping.rs
+++ b/bdk_coin_select/src/coin_grouping.rs
@@ -1,0 +1,89 @@
+use alloc::vec::Vec;
+use alloc::string::String;
+
+
+use bdk_chain::{ FullTxOut, sparse_chain::ChainPosition, collections::{ HashSet, HashMap} };
+use crate::WeightedValue;
+use crate::TXIN_BASE_WEIGHT;
+
+#[derive(Clone, Debug)]
+pub enum CoinGroupingStrategy {
+    AddressReuse,
+}
+
+pub type CoinGroup = (WeightedValue, HashSet<usize>);
+
+impl From<&CoinGroup> for WeightedValue {
+    fn from(group: &CoinGroup) -> Self {
+        group.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum CoinGroupError {
+    UnknownStrategy(String)
+}
+
+
+impl core::fmt::Display for CoinGroupError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            CoinGroupError::UnknownStrategy(strategy) => write!(f, "{} grouping strategy is not supported", strategy)
+        }
+    }
+}
+
+impl std::error::Error for CoinGroupError {}
+
+
+
+impl core::str::FromStr for CoinGroupingStrategy {
+    type Err = CoinGroupError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "address-reuse" => CoinGroupingStrategy::AddressReuse,
+            unknown => return Err(CoinGroupError::UnknownStrategy(String::from(unknown)))
+        })
+    }
+}
+
+
+pub fn apply_grouping<P: ChainPosition, AK: bdk_tmp_plan::CanDerive + Clone>(candidates: &Vec<(bdk_tmp_plan::Plan<AK>, FullTxOut<P>)>, grouping_strategy: Option<CoinGroupingStrategy>) -> Vec<CoinGroup> {
+    let mut script_coingroup_map = HashMap::new();
+    match grouping_strategy {
+        Some(strategy) => match strategy {
+            CoinGroupingStrategy::AddressReuse => {
+                candidates.iter()
+                .enumerate()
+                .for_each(|(idx, (plan, utxo))| {
+                    let coin_group = script_coingroup_map.entry(utxo.txout.script_pubkey.clone()).or_insert((WeightedValue::new(
+                        utxo.txout.value,
+                        plan.expected_weight() as _,
+                        plan.witness_version().is_some(),
+                    ),
+                    HashSet::from([idx])));
+                    coin_group.1.insert(idx);
+                    coin_group.0.value += utxo.txout.value;
+                    coin_group.0.weight += plan.expected_weight() as u32 + TXIN_BASE_WEIGHT;
+                    coin_group.0.input_count += 1;
+                    coin_group.0.is_segwit |= plan.witness_version().is_some();
+                });
+                script_coingroup_map.into_values().collect::<Vec<CoinGroup>>()
+            }
+        },
+        None => {
+            candidates.iter()
+            .enumerate()
+            .map(|(idx, (plan, utxo))| {
+                (WeightedValue::new(
+                    utxo.txout.value,
+                    plan.expected_weight() as u32,
+                    plan.witness_version().is_some(),
+                ),
+                HashSet::from([idx]))
+            })
+            .collect::<Vec<CoinGroup>>()
+        }
+        
+    }
+}

--- a/bdk_coin_select/src/lib.rs
+++ b/bdk_coin_select/src/lib.rs
@@ -21,6 +21,9 @@ pub use coin_selector::*;
 mod bnb;
 pub use bnb::*;
 
+mod coin_grouping;
+pub use coin_grouping::*;
+
 /// Txin "base" fields include `outpoint` (32+4) and `nSequence` (4). This does not include
 /// `scriptSigLen` or `scriptSig`.
 pub const TXIN_BASE_WEIGHT: u32 = (32 + 4 + 4) * 4;

--- a/bdk_esplora_example/src/main.rs
+++ b/bdk_esplora_example/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> anyhow::Result<()> {
     let esplora_url = match args.network {
         Network::Bitcoin => "https://mempool.space/api",
         Network::Testnet => "https://mempool.space/testnet/api",
-        Network::Regtest => "http://localhost:3000",
+        Network::Regtest => "http://localhost:3002",
         Network::Signet => "https://mempool.space/signet/api",
     };
 


### PR DESCRIPTION
This PR adds an implementation of Coin Grouping to Coin Selection.

I have also added an example to demonstrate how to use the coin-grouping features.

To try it, you will have to manually test it using one of the blockchain clients. Added a command to the CLI that allows you to coingroup following a particular strategy. The only strategy supported right now is Address Reuse. If you run the CLI command with Address Reuse as your grouping strategy. The program will execute coinselection with grouping and without grouping and will show you the waste in each case. Here is command to run for coingrouping

```
cargo run -- --network regtest coingroup <amount> <address> --coin-group address-reuse -c bnb
```