### PR TITLE
Introduce `lookahead` for `KeychainTxOutIndex`

### DIFF
--- a/bdk_chain/src/chain_graph.rs
+++ b/bdk_chain/src/chain_graph.rs
@@ -451,13 +451,13 @@ impl<P, T> AsRef<TxGraph<T>> for ChainGraph<P, T> {
 }
 
 impl<P, T: AsTransaction> ForEachTxout for ChainGraph<P, T> {
-    fn for_each_txout(&self, f: &mut impl FnMut((OutPoint, &TxOut))) {
+    fn for_each_txout(&self, f: impl FnMut((OutPoint, &TxOut))) {
         self.graph.for_each_txout(f)
     }
 }
 
 impl<P, T: AsTransaction> ForEachTxout for ChangeSet<P, T> {
-    fn for_each_txout(&self, f: &mut impl FnMut((OutPoint, &TxOut))) {
+    fn for_each_txout(&self, f: impl FnMut((OutPoint, &TxOut))) {
         self.graph.for_each_txout(f)
     }
 }

--- a/bdk_chain/src/chain_graph.rs
+++ b/bdk_chain/src/chain_graph.rs
@@ -2,7 +2,7 @@ use crate::{
     collections::HashSet,
     sparse_chain::{self, ChainPosition, SparseChain},
     tx_graph::{self, TxGraph},
-    AsTransaction, BlockId, ForEachTxout, FullTxOut, IntoOwned, TxHeight,
+    AsTransaction, BlockId, ForEachTxOut, FullTxOut, IntoOwned, TxHeight,
 };
 use alloc::{borrow::Cow, string::ToString, vec::Vec};
 use bitcoin::{OutPoint, Transaction, TxOut, Txid};
@@ -450,13 +450,13 @@ impl<P, T> AsRef<TxGraph<T>> for ChainGraph<P, T> {
     }
 }
 
-impl<P, T: AsTransaction> ForEachTxout for ChainGraph<P, T> {
+impl<P, T: AsTransaction> ForEachTxOut for ChainGraph<P, T> {
     fn for_each_txout(&self, f: impl FnMut((OutPoint, &TxOut))) {
         self.graph.for_each_txout(f)
     }
 }
 
-impl<P, T: AsTransaction> ForEachTxout for ChangeSet<P, T> {
+impl<P, T: AsTransaction> ForEachTxOut for ChangeSet<P, T> {
     fn for_each_txout(&self, f: impl FnMut((OutPoint, &TxOut))) {
         self.graph.for_each_txout(f)
     }

--- a/bdk_chain/src/keychain.rs
+++ b/bdk_chain/src/keychain.rs
@@ -9,7 +9,7 @@ use crate::{
     collections::BTreeMap,
     sparse_chain::ChainPosition,
     tx_graph::TxGraph,
-    AsTransaction, ForEachTxout,
+    AsTransaction, ForEachTxOut,
 };
 
 #[cfg(feature = "miniscript")]
@@ -184,7 +184,7 @@ impl<K, P, T> AsRef<TxGraph<T>> for KeychainScan<K, P, T> {
     }
 }
 
-impl<K, P, T: AsTransaction> ForEachTxout for KeychainChangeSet<K, P, T> {
+impl<K, P, T: AsTransaction> ForEachTxOut for KeychainChangeSet<K, P, T> {
     fn for_each_txout(&self, f: impl FnMut((bitcoin::OutPoint, &bitcoin::TxOut))) {
         self.chain_graph.for_each_txout(f)
     }

--- a/bdk_chain/src/keychain.rs
+++ b/bdk_chain/src/keychain.rs
@@ -185,7 +185,7 @@ impl<K, P, T> AsRef<TxGraph<T>> for KeychainScan<K, P, T> {
 }
 
 impl<K, P, T: AsTransaction> ForEachTxout for KeychainChangeSet<K, P, T> {
-    fn for_each_txout(&self, f: &mut impl FnMut((bitcoin::OutPoint, &bitcoin::TxOut))) {
+    fn for_each_txout(&self, f: impl FnMut((bitcoin::OutPoint, &bitcoin::TxOut))) {
         self.chain_graph.for_each_txout(f)
     }
 }

--- a/bdk_chain/src/keychain.rs
+++ b/bdk_chain/src/keychain.rs
@@ -1,4 +1,4 @@
-//! Modules for keychain based structures.
+//! Module for keychain based structures.
 //!
 //! A keychain here is a set of application defined indexes for a minscript descriptor where we can
 //! derive script pubkeys at a particular derivation index. The application's index is simply

--- a/bdk_chain/src/keychain/keychain_tracker.rs
+++ b/bdk_chain/src/keychain/keychain_tracker.rs
@@ -64,7 +64,7 @@ where
     {
         let mut derivation_indices = scan.last_active_indices.clone();
         derivation_indices.retain(|keychain, index| {
-            match self.txout_index.derivation_index(keychain) {
+            match self.txout_index.last_stored_index(keychain) {
                 Some(existing) => *index > existing,
                 None => true,
             }

--- a/bdk_chain/src/keychain/keychain_tracker.rs
+++ b/bdk_chain/src/keychain/keychain_tracker.rs
@@ -43,7 +43,7 @@ where
 
     /// Get the internal map of keychains to their descriptors. This is just shorthand for calling
     /// [`KeychainTxOutIndex::keychains`] on the internal `txout_index`.
-    pub fn keychains(&mut self) -> &BTreeMap<K, Descriptor<DescriptorPublicKey>> {
+    pub fn keychains(&mut self) -> &BTreeMap<K, (Descriptor<DescriptorPublicKey>, u32)> {
         self.txout_index.keychains()
     }
 

--- a/bdk_chain/src/keychain/keychain_tracker.rs
+++ b/bdk_chain/src/keychain/keychain_tracker.rs
@@ -94,7 +94,7 @@ where
             chain_graph,
         } = changeset;
         self.txout_index.apply_additions(derivation_indices);
-        self.txout_index.scan(&chain_graph);
+        let _ = self.txout_index.scan(&chain_graph);
         self.chain_graph.apply_changeset(chain_graph)
     }
 

--- a/bdk_chain/src/keychain/keychain_tracker.rs
+++ b/bdk_chain/src/keychain/keychain_tracker.rs
@@ -43,7 +43,7 @@ where
 
     /// Get the internal map of keychains to their descriptors. This is just shorthand for calling
     /// [`KeychainTxOutIndex::keychains`] on the internal `txout_index`.
-    pub fn keychains(&mut self) -> &BTreeMap<K, (Descriptor<DescriptorPublicKey>, u32)> {
+    pub fn keychains(&mut self) -> &BTreeMap<K, Descriptor<DescriptorPublicKey>> {
         self.txout_index.keychains()
     }
 

--- a/bdk_chain/src/keychain/keychain_tracker.rs
+++ b/bdk_chain/src/keychain/keychain_tracker.rs
@@ -64,7 +64,7 @@ where
     {
         let mut derivation_indices = scan.last_active_indices.clone();
         derivation_indices.retain(|keychain, index| {
-            match self.txout_index.last_stored_index(keychain) {
+            match self.txout_index.last_revealed_index(keychain) {
                 Some(existing) => *index > existing,
                 None => true,
             }

--- a/bdk_chain/src/keychain/keychain_txout_index.rs
+++ b/bdk_chain/src/keychain/keychain_txout_index.rs
@@ -107,7 +107,7 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     /// [`ForEachTxout`]: crate::ForEachTxout
     pub fn scan(&mut self, txouts: &impl ForEachTxout) -> DerivationAdditions<K> {
         let mut additions = DerivationAdditions::<K>::default();
-        txouts.for_each_txout(&mut |(op, txout)| additions.append(self.scan_txout(op, txout)));
+        txouts.for_each_txout(|(op, txout)| additions.append(self.scan_txout(op, txout)));
         additions
     }
 

--- a/bdk_chain/src/keychain/keychain_txout_index.rs
+++ b/bdk_chain/src/keychain/keychain_txout_index.rs
@@ -1,7 +1,7 @@
 use crate::{
     collections::*,
     miniscript::{Descriptor, DescriptorPublicKey},
-    ForEachTxout, SpkTxOutIndex,
+    ForEachTxOut, SpkTxOutIndex,
 };
 use alloc::vec::Vec;
 use bitcoin::{
@@ -104,8 +104,8 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     ///
     /// See [`ForEachTxout`] for the types that support this.
     ///
-    /// [`ForEachTxout`]: crate::ForEachTxout
-    pub fn scan(&mut self, txouts: &impl ForEachTxout) -> DerivationAdditions<K> {
+    /// [`ForEachTxout`]: crate::ForEachTxOut
+    pub fn scan(&mut self, txouts: &impl ForEachTxOut) -> DerivationAdditions<K> {
         let mut additions = DerivationAdditions::<K>::default();
         txouts.for_each_txout(|(op, txout)| additions.append(self.scan_txout(op, txout)));
         additions

--- a/bdk_chain/src/keychain/keychain_txout_index.rs
+++ b/bdk_chain/src/keychain/keychain_txout_index.rs
@@ -19,10 +19,10 @@ const DERIVED_KEY_COUNT: u32 = 1 << 31;
 /// Script pubkeys for a descriptor are revealed chronologically from index 0. I.e. If the last
 /// revealed index of a descriptor is 5, scripts of indices 0 to 4 are guaranteed to already be
 /// revealed. In addition to revealed scripts, we have a `lookahead` parameter for each keychain
-/// which defines the number of scripts to store ahead of last revealed.
+/// which defines the number of script pubkeys to store ahead of the last revealed index.
 ///
-/// Methods that may result in changes to the number of stored script pubkeys will return
-/// [`DerivationAdditions`] to reflect the changes. This can be persisted for future recovery.
+/// Methods that could update the last revealed index will return [`DerivationAdditions`] to report
+/// these changes. This can be persisted for future recovery.
 ///
 /// ## Synopsis
 ///
@@ -318,11 +318,16 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
         (spks, additions)
     }
 
-    /// Reveals script pubkeys from the descriptor **up to and including** `index`, unless the
-    /// script pubkey is already revealed.
+    /// Reveals script pubkeys of the `keychain`'s descriptor **up to and including** the
+    /// `target_index`.
     ///
-    /// Returns [`DerivationAdditions`] for new script pubkeys that have been revealed. If no
-    /// script pubkeys are revealed, [`DerivationAdditions`] will be empty.
+    /// If the `target_index` cannot be reached (due to the descriptor having no wildcard, and/or
+    /// the `target_index` is in the hardened index range), this method will do a best-effort and
+    /// reveal up to the last possible index.
+    ///
+    /// This returns an iterator of newly revealed indices (along side their scripts), and a
+    /// [`DerivationAdditions`] which reports updates to the latest revealed index. If no new script
+    /// pubkeys are revealed, both of these will be empty.
     ///
     /// # Panics
     ///

--- a/bdk_chain/src/keychain/keychain_txout_index.rs
+++ b/bdk_chain/src/keychain/keychain_txout_index.rs
@@ -374,7 +374,10 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
                 let _old_index = self.last_revealed.insert(keychain.clone(), index);
                 debug_assert!(_old_index < Some(index));
                 (
-                    Some(range_descriptor_spks(descriptor.clone(), next_index..index)),
+                    Some(range_descriptor_spks(
+                        descriptor.clone(),
+                        next_index..=index,
+                    )),
                     DerivationAdditions([(keychain.clone(), index)].into()),
                 )
             }

--- a/bdk_chain/src/spk_txout_index.rs
+++ b/bdk_chain/src/spk_txout_index.rs
@@ -67,7 +67,7 @@ impl<I: Clone + Ord> SpkTxOutIndex<I> {
     pub fn scan(&mut self, txouts: &impl ForEachTxout) -> BTreeSet<&I> {
         let mut scanned_indices = BTreeSet::new();
 
-        txouts.for_each_txout(&mut |(op, txout)| {
+        txouts.for_each_txout(|(op, txout)| {
             // The follow is copied from `scan_txout` because of lifetime issues.
             let spk_i = self.spk_indexes.get(&txout.script_pubkey);
 

--- a/bdk_chain/src/tx_data_traits.rs
+++ b/bdk_chain/src/tx_data_traits.rs
@@ -7,11 +7,11 @@ use bitcoin::{Block, OutPoint, Transaction, TxOut};
 ///
 /// We would prefer just work with things that can give us a `Iterator<Item=(OutPoint, &TxOut)>`
 /// here but rust's type system makes it extremely hard to do this (without trait objects).
-pub trait ForEachTxout {
+pub trait ForEachTxOut {
     fn for_each_txout(&self, f: impl FnMut((OutPoint, &TxOut)));
 }
 
-impl ForEachTxout for Block {
+impl ForEachTxOut for Block {
     fn for_each_txout(&self, mut f: impl FnMut((OutPoint, &TxOut))) {
         for tx in self.txdata.iter() {
             tx.for_each_txout(&mut f)
@@ -62,7 +62,7 @@ impl<'a, T: AsTransaction + Clone> AsTransaction for Cow<'a, T> {
     }
 }
 
-impl<T> ForEachTxout for T
+impl<T> ForEachTxOut for T
 where
     T: AsTransaction,
 {

--- a/bdk_chain/src/tx_data_traits.rs
+++ b/bdk_chain/src/tx_data_traits.rs
@@ -8,13 +8,13 @@ use bitcoin::{Block, OutPoint, Transaction, TxOut};
 /// We would prefer just work with things that can give us a `Iterator<Item=(OutPoint, &TxOut)>`
 /// here but rust's type system makes it extremely hard to do this (without trait objects).
 pub trait ForEachTxout {
-    fn for_each_txout(&self, f: &mut impl FnMut((OutPoint, &TxOut)));
+    fn for_each_txout(&self, f: impl FnMut((OutPoint, &TxOut)));
 }
 
 impl ForEachTxout for Block {
-    fn for_each_txout(&self, f: &mut impl FnMut((OutPoint, &TxOut))) {
+    fn for_each_txout(&self, mut f: impl FnMut((OutPoint, &TxOut))) {
         for tx in self.txdata.iter() {
-            tx.for_each_txout(f)
+            tx.for_each_txout(&mut f)
         }
     }
 }
@@ -66,7 +66,7 @@ impl<T> ForEachTxout for T
 where
     T: AsTransaction,
 {
-    fn for_each_txout(&self, f: &mut impl FnMut((OutPoint, &TxOut))) {
+    fn for_each_txout(&self, mut f: impl FnMut((OutPoint, &TxOut))) {
         let tx = self.as_tx();
         let txid = tx.txid();
         for (i, txout) in tx.output.iter().enumerate() {

--- a/bdk_chain/src/tx_graph.rs
+++ b/bdk_chain/src/tx_graph.rs
@@ -412,13 +412,13 @@ impl AsRef<TxGraph> for TxGraph {
 }
 
 impl<T: AsTransaction> ForEachTxout for Additions<T> {
-    fn for_each_txout(&self, f: &mut impl FnMut((OutPoint, &TxOut))) {
+    fn for_each_txout(&self, f: impl FnMut((OutPoint, &TxOut))) {
         self.txouts().for_each(f)
     }
 }
 
 impl<T: AsTransaction> ForEachTxout for TxGraph<T> {
-    fn for_each_txout(&self, f: &mut impl FnMut((OutPoint, &TxOut))) {
+    fn for_each_txout(&self, f: impl FnMut((OutPoint, &TxOut))) {
         self.all_txouts().for_each(f)
     }
 }

--- a/bdk_chain/src/tx_graph.rs
+++ b/bdk_chain/src/tx_graph.rs
@@ -1,4 +1,4 @@
-use crate::{collections::*, AsTransaction, ForEachTxout, IntoOwned};
+use crate::{collections::*, AsTransaction, ForEachTxOut, IntoOwned};
 use alloc::vec::Vec;
 use bitcoin::{OutPoint, Transaction, TxOut, Txid};
 use core::ops::RangeInclusive;
@@ -411,13 +411,13 @@ impl AsRef<TxGraph> for TxGraph {
     }
 }
 
-impl<T: AsTransaction> ForEachTxout for Additions<T> {
+impl<T: AsTransaction> ForEachTxOut for Additions<T> {
     fn for_each_txout(&self, f: impl FnMut((OutPoint, &TxOut))) {
         self.txouts().for_each(f)
     }
 }
 
-impl<T: AsTransaction> ForEachTxout for TxGraph<T> {
+impl<T: AsTransaction> ForEachTxOut for TxGraph<T> {
     fn for_each_txout(&self, f: impl FnMut((OutPoint, &TxOut))) {
         self.all_txouts().for_each(f)
     }

--- a/bdk_chain/tests/test_file_store.rs
+++ b/bdk_chain/tests/test_file_store.rs
@@ -119,7 +119,10 @@ fn append_changeset_truncates_invalid_bytes() {
     let mut tracker = KeychainTracker::<TestKeychain, TxHeight, Transaction>::default();
     tracker.add_keychain(TestKeychain::External, descriptor);
     let changeset = KeychainChangeSet {
-        derivation_indices: tracker.txout_index.reveal_to(&TestKeychain::External, 21).1,
+        derivation_indices: tracker
+            .txout_index
+            .reveal_to_target(&TestKeychain::External, 21)
+            .1,
         chain_graph: Default::default(),
     };
 

--- a/bdk_chain/tests/test_file_store.rs
+++ b/bdk_chain/tests/test_file_store.rs
@@ -119,7 +119,9 @@ fn append_changeset_truncates_invalid_bytes() {
     let mut tracker = KeychainTracker::<TestKeychain, TxHeight, Transaction>::default();
     tracker.add_keychain(TestKeychain::External, descriptor);
     let changeset = KeychainChangeSet {
-        derivation_indices: tracker.txout_index.store_up_to(&TestKeychain::External, 21),
+        derivation_indices: tracker
+            .txout_index
+            .set_derivation_index(&TestKeychain::External, 21),
         chain_graph: Default::default(),
     };
 

--- a/bdk_chain/tests/test_file_store.rs
+++ b/bdk_chain/tests/test_file_store.rs
@@ -119,9 +119,7 @@ fn append_changeset_truncates_invalid_bytes() {
     let mut tracker = KeychainTracker::<TestKeychain, TxHeight, Transaction>::default();
     tracker.add_keychain(TestKeychain::External, descriptor);
     let changeset = KeychainChangeSet {
-        derivation_indices: tracker
-            .txout_index
-            .set_derivation_index(&TestKeychain::External, 21),
+        derivation_indices: tracker.txout_index.store_up_to(&TestKeychain::External, 21),
         chain_graph: Default::default(),
     };
 

--- a/bdk_chain/tests/test_file_store.rs
+++ b/bdk_chain/tests/test_file_store.rs
@@ -119,7 +119,7 @@ fn append_changeset_truncates_invalid_bytes() {
     let mut tracker = KeychainTracker::<TestKeychain, TxHeight, Transaction>::default();
     tracker.add_keychain(TestKeychain::External, descriptor);
     let changeset = KeychainChangeSet {
-        derivation_indices: tracker.txout_index.store_up_to(&TestKeychain::External, 21),
+        derivation_indices: tracker.txout_index.reveal_to(&TestKeychain::External, 21),
         chain_graph: Default::default(),
     };
 

--- a/bdk_chain/tests/test_file_store.rs
+++ b/bdk_chain/tests/test_file_store.rs
@@ -119,7 +119,7 @@ fn append_changeset_truncates_invalid_bytes() {
     let mut tracker = KeychainTracker::<TestKeychain, TxHeight, Transaction>::default();
     tracker.add_keychain(TestKeychain::External, descriptor);
     let changeset = KeychainChangeSet {
-        derivation_indices: tracker.txout_index.reveal_to(&TestKeychain::External, 21),
+        derivation_indices: tracker.txout_index.reveal_to(&TestKeychain::External, 21).1,
         chain_graph: Default::default(),
     };
 

--- a/bdk_chain/tests/test_keychain_tracker.rs
+++ b/bdk_chain/tests/test_keychain_tracker.rs
@@ -29,7 +29,7 @@ fn test_insert_tx() {
         output: vec![txout],
     };
 
-    let _ = tracker.txout_index.store_up_to(&(), 5);
+    let _ = tracker.txout_index.reveal_to(&(), 5);
 
     let changeset = tracker
         .insert_tx_preview(tx.clone(), ConfirmationTime::Unconfirmed)
@@ -75,7 +75,12 @@ fn test_balance() {
         input: vec![],
         output: vec![TxOut {
             value: 13_000,
-            script_pubkey: tracker.txout_index.new_script(&Keychain::One).0 .1.clone(),
+            script_pubkey: tracker
+                .txout_index
+                .reveal_next_script_pubkey(&Keychain::One)
+                .0
+                 .1
+                .clone(),
         }],
     };
 
@@ -85,7 +90,12 @@ fn test_balance() {
         input: vec![],
         output: vec![TxOut {
             value: 7_000,
-            script_pubkey: tracker.txout_index.new_script(&Keychain::Two).0 .1.clone(),
+            script_pubkey: tracker
+                .txout_index
+                .reveal_next_script_pubkey(&Keychain::Two)
+                .0
+                 .1
+                .clone(),
         }],
     };
 
@@ -95,7 +105,12 @@ fn test_balance() {
         input: vec![TxIn::default()],
         output: vec![TxOut {
             value: 11_000,
-            script_pubkey: tracker.txout_index.new_script(&Keychain::Two).0 .1.clone(),
+            script_pubkey: tracker
+                .txout_index
+                .reveal_next_script_pubkey(&Keychain::Two)
+                .0
+                 .1
+                .clone(),
         }],
     };
 

--- a/bdk_chain/tests/test_keychain_tracker.rs
+++ b/bdk_chain/tests/test_keychain_tracker.rs
@@ -29,7 +29,7 @@ fn test_insert_tx() {
         output: vec![txout],
     };
 
-    let _ = tracker.txout_index.set_derivation_index(&(), 5);
+    let _ = tracker.txout_index.store_up_to(&(), 5);
 
     let changeset = tracker
         .insert_tx_preview(tx.clone(), ConfirmationTime::Unconfirmed)
@@ -75,7 +75,7 @@ fn test_balance() {
         input: vec![],
         output: vec![TxOut {
             value: 13_000,
-            script_pubkey: tracker.txout_index.derive_new(&Keychain::One).0 .1.clone(),
+            script_pubkey: tracker.txout_index.new_script(&Keychain::One).0 .1.clone(),
         }],
     };
 
@@ -85,7 +85,7 @@ fn test_balance() {
         input: vec![],
         output: vec![TxOut {
             value: 7_000,
-            script_pubkey: tracker.txout_index.derive_new(&Keychain::Two).0 .1.clone(),
+            script_pubkey: tracker.txout_index.new_script(&Keychain::Two).0 .1.clone(),
         }],
     };
 
@@ -95,7 +95,7 @@ fn test_balance() {
         input: vec![TxIn::default()],
         output: vec![TxOut {
             value: 11_000,
-            script_pubkey: tracker.txout_index.derive_new(&Keychain::Two).0 .1.clone(),
+            script_pubkey: tracker.txout_index.new_script(&Keychain::Two).0 .1.clone(),
         }],
     };
 

--- a/bdk_chain/tests/test_keychain_tracker.rs
+++ b/bdk_chain/tests/test_keychain_tracker.rs
@@ -29,7 +29,7 @@ fn test_insert_tx() {
         output: vec![txout],
     };
 
-    let _ = tracker.txout_index.store_up_to(&(), 5);
+    let _ = tracker.txout_index.set_derivation_index(&(), 5);
 
     let changeset = tracker
         .insert_tx_preview(tx.clone(), ConfirmationTime::Unconfirmed)

--- a/bdk_chain/tests/test_keychain_tracker.rs
+++ b/bdk_chain/tests/test_keychain_tracker.rs
@@ -29,7 +29,7 @@ fn test_insert_tx() {
         output: vec![txout],
     };
 
-    let _ = tracker.txout_index.reveal_to(&(), 5);
+    let _ = tracker.txout_index.reveal_to_target(&(), 5);
 
     let changeset = tracker
         .insert_tx_preview(tx.clone(), ConfirmationTime::Unconfirmed)
@@ -77,7 +77,7 @@ fn test_balance() {
             value: 13_000,
             script_pubkey: tracker
                 .txout_index
-                .reveal_next_script_pubkey(&Keychain::One)
+                .reveal_next_spk(&Keychain::One)
                 .0
                  .1
                 .clone(),
@@ -92,7 +92,7 @@ fn test_balance() {
             value: 7_000,
             script_pubkey: tracker
                 .txout_index
-                .reveal_next_script_pubkey(&Keychain::Two)
+                .reveal_next_spk(&Keychain::Two)
                 .0
                  .1
                 .clone(),
@@ -107,7 +107,7 @@ fn test_balance() {
             value: 11_000,
             script_pubkey: tracker
                 .txout_index
-                .reveal_next_script_pubkey(&Keychain::Two)
+                .reveal_next_spk(&Keychain::Two)
                 .0
                  .1
                 .clone(),

--- a/bdk_chain/tests/test_keychain_txout_index.rs
+++ b/bdk_chain/tests/test_keychain_txout_index.rs
@@ -38,12 +38,14 @@ fn test_store_all_up_to() {
     let derive_to: BTreeMap<_, _> =
         [(TestKeychain::External, 12), (TestKeychain::Internal, 24)].into();
     assert_eq!(
-        txout_index.store_all_up_to(&derive_to).as_inner(),
+        txout_index
+            .set_all_derivation_indices(&derive_to)
+            .as_inner(),
         &derive_to
     );
     assert_eq!(txout_index.derivation_indices(), derive_to);
     assert_eq!(
-        txout_index.store_all_up_to(&derive_to),
+        txout_index.set_all_derivation_indices(&derive_to),
         DerivationAdditions::default(),
         "no changes if we set to the same thing"
     );
@@ -112,7 +114,7 @@ fn test_wildcard_derivations() {
     // - next_derivation_index() = (26, true)
     // - derive_new() = ((26, <spk>), DerivationAdditions)
     // - next_unused() == ((16, <spk>), DerivationAdditions::is_empty())
-    let _ = txout_index.store_up_to(&TestKeychain::External, 25);
+    let _ = txout_index.set_derivation_index(&TestKeychain::External, 25);
 
     (0..=15)
         .into_iter()
@@ -194,6 +196,6 @@ fn test_non_wildcard_derivations() {
     assert_eq!(spk, (0, &external_spk));
     assert_eq!(changeset.as_inner(), &[].into());
     assert!(txout_index
-        .store_up_to(&TestKeychain::External, 200)
+        .set_derivation_index(&TestKeychain::External, 200)
         .is_empty());
 }

--- a/bdk_chain/tests/test_keychain_txout_index.rs
+++ b/bdk_chain/tests/test_keychain_txout_index.rs
@@ -38,10 +38,13 @@ fn test_set_all_derivation_indices() {
     let (mut txout_index, _, _) = init_txout_index();
     let derive_to: BTreeMap<_, _> =
         [(TestKeychain::External, 12), (TestKeychain::Internal, 24)].into();
-    assert_eq!(txout_index.reveal_all_to(&derive_to).as_inner(), &derive_to);
+    assert_eq!(
+        txout_index.reveal_all_to(&derive_to).1.as_inner(),
+        &derive_to
+    );
     assert_eq!(txout_index.last_revealed_indices(), &derive_to);
     assert_eq!(
-        txout_index.reveal_all_to(&derive_to),
+        txout_index.reveal_all_to(&derive_to).1,
         DerivationAdditions::default(),
         "no changes if we set to the same thing"
     );
@@ -67,6 +70,7 @@ fn test_lookahead() {
         assert_eq!(
             txout_index
                 .reveal_to(&TestKeychain::External, index)
+                .1
                 .as_inner(),
             &[(TestKeychain::External, index)].into()
         );
@@ -113,6 +117,7 @@ fn test_lookahead() {
     assert_eq!(
         txout_index
             .reveal_to(&TestKeychain::Internal, 24)
+            .1
             .as_inner(),
         &[(TestKeychain::Internal, 24)].into()
     );
@@ -299,5 +304,6 @@ fn test_non_wildcard_derivations() {
     assert_eq!(changeset.as_inner(), &[].into());
     assert!(txout_index
         .reveal_to(&TestKeychain::External, 200)
+        .1
         .is_empty());
 }

--- a/bdk_chain/tests/test_keychain_txout_index.rs
+++ b/bdk_chain/tests/test_keychain_txout_index.rs
@@ -6,7 +6,6 @@ use bdk_chain::{
     collections::BTreeMap,
     keychain::{DerivationAdditions, KeychainTxOutIndex},
 };
-use bitcoin::{OutPoint, TxOut};
 
 use miniscript::{Descriptor, DescriptorPublicKey};
 
@@ -50,35 +49,35 @@ fn test_store_all_up_to() {
     );
 }
 
-#[test]
-fn test_pad_all_with_unused() {
-    let (mut txout_index, external_desc, _) = init_txout_index();
+// #[test]
+// fn test_pad_all_with_unused() {
+//     let (mut txout_index, external_desc, _) = init_txout_index();
 
-    let external_spk3 = external_desc.at_derivation_index(3).script_pubkey();
+//     let external_spk3 = external_desc.at_derivation_index(3).script_pubkey();
 
-    assert_eq!(
-        txout_index
-            .store_up_to(&TestKeychain::External, 3)
-            .as_inner(),
-        &[(TestKeychain::External, 3)].into(),
-    );
-    txout_index.scan_txout(
-        OutPoint::default(),
-        &TxOut {
-            value: 420,
-            script_pubkey: external_spk3,
-        },
-    );
+//     assert_eq!(
+//         txout_index
+//             .store_up_to(&TestKeychain::External, 3)
+//             .as_inner(),
+//         &[(TestKeychain::External, 3)].into(),
+//     );
+//     txout_index.scan_txout(
+//         OutPoint::default(),
+//         &TxOut {
+//             value: 420,
+//             script_pubkey: external_spk3,
+//         },
+//     );
 
-    assert_eq!(
-        txout_index.pad_all_with_unused(5).as_inner(),
-        &[(TestKeychain::External, 8), (TestKeychain::Internal, 4)].into(),
-    );
-    assert_eq!(
-        txout_index.derivation_indices(),
-        [(TestKeychain::External, 8), (TestKeychain::Internal, 4)].into()
-    );
-}
+//     assert_eq!(
+//         txout_index.pad_all_with_unused(5).as_inner(),
+//         &[(TestKeychain::External, 8), (TestKeychain::Internal, 4)].into(),
+//     );
+//     assert_eq!(
+//         txout_index.derivation_indices(),
+//         [(TestKeychain::External, 8), (TestKeychain::Internal, 4)].into()
+//     );
+// }
 
 #[test]
 fn test_wildcard_derivations() {

--- a/bdk_chain/tests/test_keychain_txout_index.rs
+++ b/bdk_chain/tests/test_keychain_txout_index.rs
@@ -302,8 +302,8 @@ fn test_non_wildcard_derivations() {
     let (spk, changeset) = txout_index.next_unused_spk(&TestKeychain::External);
     assert_eq!(spk, (0, &external_spk));
     assert_eq!(changeset.as_inner(), &[].into());
-    assert!(txout_index
-        .reveal_to_target(&TestKeychain::External, 200)
-        .1
-        .is_empty());
+    let (revealed_spks, revealed_additions) =
+        txout_index.reveal_to_target(&TestKeychain::External, 200);
+    assert!(revealed_spks.is_none());
+    assert!(revealed_additions.is_empty());
 }

--- a/bdk_cli_lib/src/lib.rs
+++ b/bdk_cli_lib/src/lib.rs
@@ -385,7 +385,6 @@ pub fn create_tx<P: ChainPosition>(
             .keychains()
             .get(&internal_keychain)
             .expect("must exist")
-            .0
             .at_derivation_index(change_index),
         &assets,
     )
@@ -403,7 +402,6 @@ pub fn create_tx<P: ChainPosition>(
             .keychains()
             .get(&internal_keychain)
             .expect("must exist")
-            .0
             .dust_value(),
         ..CoinSelectorOpt::fund_outputs(
             &outputs,
@@ -684,7 +682,6 @@ pub fn planned_utxos<'a, AK: bdk_tmp_plan::CanDerive + Clone, P: ChainPosition>(
                         .keychains()
                         .get(keychain)
                         .expect("must exist since we have a utxo for it")
-                        .0
                         .at_derivation_index(*derivation_index),
                     assets,
                 )?,

--- a/bdk_cli_lib/src/lib.rs
+++ b/bdk_cli_lib/src/lib.rs
@@ -192,8 +192,8 @@ where
     let txout_index = &mut tracker.txout_index;
 
     let addr_cmmd_output = match addr_cmd {
-        AddressCmd::Next => Some(txout_index.next_unused_script(&Keychain::External)),
-        AddressCmd::New => Some(txout_index.new_script(&Keychain::External)),
+        AddressCmd::Next => Some(txout_index.next_unused_script_pubkey(&Keychain::External)),
+        AddressCmd::New => Some(txout_index.reveal_next_script_pubkey(&Keychain::External)),
         _ => None,
     };
 
@@ -215,7 +215,7 @@ where
             Ok(())
         }
         AddressCmd::Index => {
-            for (keychain, derivation_index) in txout_index.last_stored_indices() {
+            for (keychain, derivation_index) in txout_index.last_revealed_indices() {
                 println!("{:?}: {}", keychain, derivation_index);
             }
             Ok(())
@@ -225,7 +225,7 @@ where
                 true => Keychain::Internal,
                 false => Keychain::External,
             };
-            for (index, spk) in txout_index.stored_scripts(&target_keychain) {
+            for (index, spk) in txout_index.revealed_script_pubkeys(&target_keychain) {
                 let address = Address::from_script(&spk, network)
                     .expect("should always be able to derive address");
                 println!(
@@ -374,7 +374,7 @@ pub fn create_tx<P: ChainPosition>(
 
     let ((change_index, change_script), change_additions) = keychain_tracker
         .txout_index
-        .next_unused_script(&internal_keychain);
+        .next_unused_script_pubkey(&internal_keychain);
     additions.append(change_additions);
 
     // Clone to drop the immutable reference.

--- a/bdk_cli_lib/src/lib.rs
+++ b/bdk_cli_lib/src/lib.rs
@@ -385,6 +385,7 @@ pub fn create_tx<P: ChainPosition>(
             .keychains()
             .get(&internal_keychain)
             .expect("must exist")
+            .0
             .at_derivation_index(change_index),
         &assets,
     )
@@ -402,6 +403,7 @@ pub fn create_tx<P: ChainPosition>(
             .keychains()
             .get(&internal_keychain)
             .expect("must exist")
+            .0
             .dust_value(),
         ..CoinSelectorOpt::fund_outputs(
             &outputs,
@@ -682,6 +684,7 @@ pub fn planned_utxos<'a, AK: bdk_tmp_plan::CanDerive + Clone, P: ChainPosition>(
                         .keychains()
                         .get(keychain)
                         .expect("must exist since we have a utxo for it")
+                        .0
                         .at_derivation_index(*derivation_index),
                     assets,
                 )?,

--- a/bdk_cli_lib/src/lib.rs
+++ b/bdk_cli_lib/src/lib.rs
@@ -192,8 +192,8 @@ where
     let txout_index = &mut tracker.txout_index;
 
     let addr_cmmd_output = match addr_cmd {
-        AddressCmd::Next => Some(txout_index.next_unused(&Keychain::External)),
-        AddressCmd::New => Some(txout_index.derive_new(&Keychain::External)),
+        AddressCmd::Next => Some(txout_index.next_unused_script(&Keychain::External)),
+        AddressCmd::New => Some(txout_index.new_script(&Keychain::External)),
         _ => None,
     };
 
@@ -215,7 +215,7 @@ where
             Ok(())
         }
         AddressCmd::Index => {
-            for (keychain, derivation_index) in txout_index.derivation_indices() {
+            for (keychain, derivation_index) in txout_index.last_stored_indices() {
                 println!("{:?}: {}", keychain, derivation_index);
             }
             Ok(())
@@ -225,7 +225,7 @@ where
                 true => Keychain::Internal,
                 false => Keychain::External,
             };
-            for (index, spk) in txout_index.stored_scripts_of_keychain(&target_keychain) {
+            for (index, spk) in txout_index.stored_scripts(&target_keychain) {
                 let address = Address::from_script(&spk, network)
                     .expect("should always be able to derive address");
                 println!(
@@ -372,8 +372,9 @@ pub fn create_tx<P: ChainPosition>(
         Keychain::External
     };
 
-    let ((change_index, change_script), change_additions) =
-        keychain_tracker.txout_index.next_unused(&internal_keychain);
+    let ((change_index, change_script), change_additions) = keychain_tracker
+        .txout_index
+        .next_unused_script(&internal_keychain);
     additions.append(change_additions);
 
     // Clone to drop the immutable reference.

--- a/bdk_cli_lib/src/lib.rs
+++ b/bdk_cli_lib/src/lib.rs
@@ -192,8 +192,8 @@ where
     let txout_index = &mut tracker.txout_index;
 
     let addr_cmmd_output = match addr_cmd {
-        AddressCmd::Next => Some(txout_index.next_unused_script_pubkey(&Keychain::External)),
-        AddressCmd::New => Some(txout_index.reveal_next_script_pubkey(&Keychain::External)),
+        AddressCmd::Next => Some(txout_index.next_unused_spk(&Keychain::External)),
+        AddressCmd::New => Some(txout_index.reveal_next_spk(&Keychain::External)),
         _ => None,
     };
 
@@ -225,7 +225,7 @@ where
                 true => Keychain::Internal,
                 false => Keychain::External,
             };
-            for (index, spk) in txout_index.revealed_script_pubkeys(&target_keychain) {
+            for (index, spk) in txout_index.revealed_spks(&target_keychain) {
                 let address = Address::from_script(&spk, network)
                     .expect("should always be able to derive address");
                 println!(
@@ -374,7 +374,7 @@ pub fn create_tx<P: ChainPosition>(
 
     let ((change_index, change_script), change_additions) = keychain_tracker
         .txout_index
-        .next_unused_script_pubkey(&internal_keychain);
+        .next_unused_spk(&internal_keychain);
     additions.append(change_additions);
 
     // Clone to drop the immutable reference.

--- a/bdk_electrum_example/src/main.rs
+++ b/bdk_electrum_example/src/main.rs
@@ -85,7 +85,7 @@ fn main() -> anyhow::Result<()> {
                 let tracker = &*tracker.lock().unwrap();
                 let spk_iterators = tracker
                     .txout_index
-                    .scripts_of_all_keychains()
+                    .all_keychain_scripts()
                     .into_iter()
                     .map(|(keychain, iter)| {
                         let mut first = true;

--- a/bdk_electrum_example/src/main.rs
+++ b/bdk_electrum_example/src/main.rs
@@ -85,7 +85,7 @@ fn main() -> anyhow::Result<()> {
                 let tracker = &*tracker.lock().unwrap();
                 let spk_iterators = tracker
                     .txout_index
-                    .all_keychain_scripts()
+                    .all_keychain_script_pubkeys()
                     .into_iter()
                     .map(|(keychain, iter)| {
                         let mut first = true;

--- a/bdk_electrum_example/src/main.rs
+++ b/bdk_electrum_example/src/main.rs
@@ -85,7 +85,7 @@ fn main() -> anyhow::Result<()> {
                 let tracker = &*tracker.lock().unwrap();
                 let spk_iterators = tracker
                     .txout_index
-                    .all_keychain_script_pubkeys()
+                    .keychain_spks_of_all()
                     .into_iter()
                     .map(|(keychain, iter)| {
                         let mut first = true;

--- a/bdk_esplora_example/src/main.rs
+++ b/bdk_esplora_example/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> anyhow::Result<()> {
                 let tracker = &*keychain_tracker.lock().unwrap();
                 let spk_iterators = tracker
                     .txout_index
-                    .scripts_of_all_keychains()
+                    .all_keychain_scripts()
                     .into_iter()
                     .map(|(keychain, iter)| {
                         let mut first = true;

--- a/bdk_esplora_example/src/main.rs
+++ b/bdk_esplora_example/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> anyhow::Result<()> {
                 let tracker = &*keychain_tracker.lock().unwrap();
                 let spk_iterators = tracker
                     .txout_index
-                    .all_keychain_script_pubkeys()
+                    .keychain_spks_of_all()
                     .into_iter()
                     .map(|(keychain, iter)| {
                         let mut first = true;

--- a/bdk_esplora_example/src/main.rs
+++ b/bdk_esplora_example/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> anyhow::Result<()> {
                 let tracker = &*keychain_tracker.lock().unwrap();
                 let spk_iterators = tracker
                     .txout_index
-                    .all_keychain_scripts()
+                    .all_keychain_script_pubkeys()
                     .into_iter()
                     .map(|(keychain, iter)| {
                         let mut first = true;


### PR DESCRIPTION
closes #163 

The `lookahead` is the number of scripts to cache ahead of the last derived script index.

Scanning methods now return `DerivationAdditions` and replenish the internal `lookahead`.

### TODO

- [x] Add `lookaheads(&self) -> &BTreeMap<K, u32>`
- [x] Rebrand `store..` methods as `set_derivation_index`
- [x] Better documentation
- [x] Tests