### PR TITLE
Test esplora example

### DIFF
--- a/bdk_esplora_example/Cargo.toml
+++ b/bdk_esplora_example/Cargo.toml
@@ -10,9 +10,8 @@ edition = "2021"
 bdk_chain = { path = "../bdk_chain", features = ["serde", "miniscript", "file_store"] }
 bdk_cli = { path = "../bdk_cli_lib" }
 serde = { version = "1", features = ["derive"] }
-esplora-client = { git = "https://github.com/rajarshimaitra/rust-esplora-client.git", branch = "get_recent_blocks"}
+esplora-client = { version = "0.3.0", default-features = false, features = ["blocking"] }
 
 [dev-dependencies]
-lazy_static = "1.4.0"
 electrsd = { version = "0.22.0", features = ["legacy", "esplora_a33e97e1", "bitcoind_22_0"] }
 

--- a/bdk_esplora_example/src/esplora.rs
+++ b/bdk_esplora_example/src/esplora.rs
@@ -195,9 +195,9 @@ impl Client {
         // Depending upon service providers number of recent blocks returned will vary.
         // esplora returns 10.
         // mempool.space returns 15.
-        for block in self.client.get_recent_blocks(None)? {
+        for block in self.client.get_blocks(None)? {
             let block_id = BlockId {
-                height: block.height,
+                height: block.time.height,
                 hash: block.id,
             };
             let _ = update


### PR DESCRIPTION
This PR implements basic test for `bdk_esplora_example`. The following test are implement in this PR:

- Test for confirmed balance
- Test for unconfirmed balance
- Test for Reorg
- Test for sending a tx

I had to implement a workaround for the reorg test to work for Esplora because after a reorg on `bitcoind`, electrs still shows the transactions in reorged blocks as confirmed. I followed @notmandatory answer to this [stack exchange question](https://bitcoin.stackexchange.com/questions/114044/how-can-i-simulate-a-reorg-for-testing)