### PR TITLE
[cli] Remove Broadcast trait

### DIFF
--- a/bdk_esplora_example/src/esplora.rs
+++ b/bdk_esplora_example/src/esplora.rs
@@ -1,5 +1,5 @@
 use bdk_chain::{
-    bitcoin::{BlockHash, Script, Transaction},
+    bitcoin::{BlockHash, Script},
     chain_graph::ChainGraph,
     keychain::KeychainScan,
     sparse_chain, BlockId, ConfirmationTime,
@@ -206,12 +206,5 @@ impl Client {
         }
 
         Ok(wallet_scan)
-    }
-}
-
-impl bdk_cli::Broadcast for Client {
-    type Error = esplora_client::Error;
-    fn broadcast(&self, tx: &Transaction) -> Result<(), Self::Error> {
-        Ok(self.client.broadcast(tx)?)
     }
 }

--- a/bdk_esplora_example/src/main.rs
+++ b/bdk_esplora_example/src/main.rs
@@ -48,7 +48,7 @@ fn main() -> anyhow::Result<()> {
         general_command => {
             return bdk_cli::handle_commands(
                 general_command,
-                client,
+                |transaction| Ok(client.client.broadcast(transaction)?),
                 &keychain_tracker,
                 &db,
                 args.network,


### PR DESCRIPTION
In favor of passing a closure that can do the broadcast. ~`Broadcast` was forcing us to create a "client" too early in the cli workflow~ *this problem was orthogonal*. It also forces us to wrap stuff in `main.rs` so we can implement the trait.